### PR TITLE
Enable running with local authenticator build

### DIFF
--- a/5_build_and_push_containers.sh
+++ b/5_build_and_push_containers.sh
@@ -59,3 +59,13 @@ else
   popd
 
 fi
+
+if [[ $LOCAL_AUTHENTICATOR == true ]]; then
+  # Re-tag the locally-built conjur-authn-k8s-client:dev image
+  authn_image=$(platform_image conjur-authn-k8s-client)
+  docker tag conjur-authn-k8s-client:dev $authn_image
+
+  if [[ is_minienv != true ]]; then
+    docker push $authn_image
+  fi
+fi

--- a/6_deploy_test_app.sh
+++ b/6_deploy_test_app.sh
@@ -61,6 +61,12 @@ init_connection_specs() {
   test_sidecar_app_docker_image=$(platform_image test-sidecar-app)
   test_init_app_docker_image=$(platform_image test-init-app)
 
+  if [[ $LOCAL_AUTHENTICATOR == true ]]; then
+    authenticator_client_image=$(platform_image conjur-authn-k8s-client)
+  else
+    authenticator_client_image="cyberark/conjur-kubernetes-authenticator"
+  fi
+
   conjur_appliance_url=https://conjur-follower.$CONJUR_NAMESPACE_NAME.svc.cluster.local/api
   conjur_authenticator_url=https://conjur-follower.$CONJUR_NAMESPACE_NAME.svc.cluster.local/api/authn-k8s/$AUTHENTICATOR_ID
 
@@ -103,6 +109,7 @@ deploy_sidecar_app() {
   sleep 5
 
   sed -e "s#{{ TEST_APP_DOCKER_IMAGE }}#$test_sidecar_app_docker_image#g" ./$PLATFORM/test-app-summon-sidecar.yml |
+    sed -e "s#{{ AUTHENTICATOR_CLIENT_IMAGE }}#$authenticator_client_image#g" |
     sed -e "s#{{ IMAGE_PULL_POLICY }}#$IMAGE_PULL_POLICY#g" |
     sed -e "s#{{ CONJUR_VERSION }}#$CONJUR_VERSION#g" |
     sed -e "s#{{ CONJUR_ACCOUNT }}#$CONJUR_ACCOUNT#g" |
@@ -132,6 +139,7 @@ deploy_init_container_app() {
   sleep 5
 
   sed -e "s#{{ TEST_APP_DOCKER_IMAGE }}#$test_init_app_docker_image#g" ./$PLATFORM/test-app-summon-init.yml |
+    sed -e "s#{{ AUTHENTICATOR_CLIENT_IMAGE }}#$authenticator_client_image#g" |
     sed -e "s#{{ IMAGE_PULL_POLICY }}#$IMAGE_PULL_POLICY#g" |
     sed -e "s#{{ CONJUR_VERSION }}#$CONJUR_VERSION#g" |
     sed -e "s#{{ CONJUR_ACCOUNT }}#$CONJUR_ACCOUNT#g" |

--- a/README.md
+++ b/README.md
@@ -118,3 +118,18 @@ available.
 ## OpenShift
 The test app uses the Conjur Ruby API, configured with the access token provided by the authenticator
 sidecar, to retrieve a secret value from Conjur.
+
+# Development
+
+If you are using this repository for development purposes, there is some
+additional functionality that you may find useful.
+
+- Setting the `LOCAL_AUTHENTICATOR` environment variable to `true` will push
+  the Conjur K8s authenticator client from your local Docker registry to the
+  remote registry (if used), and will use that image rather than the image
+  stored in DockerHub.
+  This can be useful if you are working on changes to the [authenticator client](https://github.com/cyberark/conjur-authn-k8s-client).
+  If you run `./bin/build` in that project to generate a local Docker image
+  `conjur-authn-k8s-client:dev` and set `LOCAL_AUTHENTICATOR=true`, then when
+  you run the `./start` script in this repo the demo apps will be deployed with
+  your local build of the authenticator.

--- a/kubernetes/test-app-summon-init.yml
+++ b/kubernetes/test-app-summon-init.yml
@@ -60,7 +60,7 @@ spec:
             name: conjur-access-token
             readOnly: true
       initContainers:
-      - image: cyberark/conjur-kubernetes-authenticator
+      - image: {{ AUTHENTICATOR_CLIENT_IMAGE }}
         imagePullPolicy: Always
         name: authenticator
         env:

--- a/kubernetes/test-app-summon-sidecar.yml
+++ b/kubernetes/test-app-summon-sidecar.yml
@@ -59,7 +59,7 @@ spec:
           - mountPath: /run/conjur
             name: conjur-access-token
             readOnly: true
-      - image: cyberark/conjur-kubernetes-authenticator
+      - image: {{ AUTHENTICATOR_CLIENT_IMAGE }}
         imagePullPolicy: Always
         name: authenticator
         env:

--- a/utils.sh
+++ b/utils.sh
@@ -5,6 +5,7 @@ PLATFORM="${PLATFORM:-kubernetes}"  # default to kubernetes if env var not set
 
 MINIKUBE="${MINIKUBE:-false}"
 MINISHIFT="${MINISHIFT:-false}"
+LOCAL_AUTHENTICATOR="${LOCAL_AUTHENTICATOR:-false}"
 
 if [ $PLATFORM = 'kubernetes' ]; then
     cli=kubectl


### PR DESCRIPTION
When the LOCAL_AUTHENTICATOR env var is set to true, the scripts will use a
local authenticator client image to deploy the test apps.