### PR TITLE
Update scripts to enable follower-only in k8s flow

### DIFF
--- a/2_load_conjur_policies.sh
+++ b/2_load_conjur_policies.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 . utils.sh
 
-announce "Loading Conjur policy."
+announce "Generating Conjur policy."
 
 pushd policy
   mkdir -p ./generated
@@ -17,62 +17,34 @@ pushd policy
     sed -e "s#{{ TEST_APP_NAMESPACE_NAME }}#$TEST_APP_NAMESPACE_NAME#g" > ./generated/app-identity.yml
 popd
 
-
-set_namespace $CONJUR_NAMESPACE_NAME
-conjur_cli_pod=$(get_conjur_cli_pod_name)
-
-if [ $PLATFORM = 'kubernetes' ]; then
-  kubectl exec $conjur_cli_pod -- rm -rf /policy
-  kubectl cp ./policy $conjur_cli_pod:/policy
-elif [ $PLATFORM = 'openshift' ]; then
-  oc rsync ./policy $conjur_cli_pod:/
-fi
-
-$cli exec $conjur_cli_pod -- conjur authn login -u admin -p $CONJUR_ADMIN_PASSWORD
-
-POLICY_FILE_LIST="policy/users.yml
-policy/generated/project-authn.yml
-policy/generated/cluster-authn-svc.yml
-policy/generated/app-identity.yml
-policy/app-access.yml"
-
-for i in $POLICY_FILE_LIST; do
-  echo "Loading policy $i..."
-  if [ $CONJUR_VERSION = '4' ]; then
-    $cli exec $conjur_cli_pod -- conjur policy load --as-group security_admin /$i
-  elif [ $CONJUR_VERSION = '5' ]; then
-    $cli exec $conjur_cli_pod -- conjur policy load root $i
-  fi
-done
-    
-$cli exec $conjur_cli_pod -- rm -rf ./policy
-
-echo "Conjur policy loaded."
-
+# Create the random database password
 password=$(openssl rand -hex 12)
 
-# load secret values for each app
-readonly APPS=(
-  "test-summon-init-app"
-  "test-summon-sidecar-app"
-  "test-secretless-app"
-)
+if [[ "${DEPLOY_MASTER_CLUSTER}" == "true" ]]; then
 
-for app_name in "${APPS[@]}"; do
-  echo "Loading secret values for $app_name"
-  $cli exec $conjur_cli_pod -- conjur variable values add "$app_name-db/password" $password
-  $cli exec $conjur_cli_pod -- conjur variable values add "$app_name-db/username" "test_app"
+  announce "Loading Conjur policy."
 
-  db_url="$app_name-backend.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:5432/postgres"
+  set_namespace "$CONJUR_NAMESPACE_NAME"
+  conjur_cli_pod=$(get_conjur_cli_pod_name)
 
-  if [[ "$app_name" = "test-secretless-app" ]]; then
-    # Secretless doesn't require the full connection URL, just the host/port
-    # and an optional database
-    $cli exec $conjur_cli_pod -- conjur variable values add "$app_name-db/url" "$db_url"
-  else
-    $cli exec $conjur_cli_pod -- conjur variable values add "$app_name-db/url" "postgresql://$db_url"
-  fi
-done
+  $cli exec $conjur_cli_pod -- rm -rf /policy
+  $cli cp ./policy $conjur_cli_pod:/policy
+
+  $cli exec $conjur_cli_pod -- \
+    bash -c "
+      CONJUR_ADMIN_PASSWORD=${CONJUR_ADMIN_PASSWORD} \
+      DB_PASSWORD=${password} \
+      TEST_APP_NAMESPACE_NAME=${TEST_APP_NAMESPACE_NAME} \
+      CONJUR_VERSION=${CONJUR_VERSION} \
+      ./policy/load_policies.sh
+    "
+
+  $cli exec $conjur_cli_pod -- rm -rf ./policy
+
+  echo "Conjur policy loaded."
+
+  set_namespace "$TEST_APP_NAMESPACE_NAME"
+fi
 
 # Set DB password in DB schema
 pushd pg
@@ -80,7 +52,3 @@ pushd pg
 popd
 
 announce "Added DB password value: $password"
-
-$cli exec $conjur_cli_pod -- conjur authn logout
-
-set_namespace $TEST_APP_NAMESPACE_NAME

--- a/6_deploy_test_app.sh
+++ b/6_deploy_test_app.sh
@@ -100,7 +100,8 @@ deploy_sidecar_app() {
   $cli delete --ignore-not-found \
     deployment/test-app-summon-sidecar \
     service/test-app-summon-sidecar \
-    serviceaccount/test-app-summon-sidecar
+    serviceaccount/test-app-summon-sidecar \
+    serviceaccount/oc-test-app-summon-sidecar
 
   if [ $PLATFORM = 'openshift' ]; then
     oc delete --ignore-not-found deploymentconfig/test-app-summon-sidecar
@@ -130,7 +131,8 @@ deploy_init_container_app() {
   $cli delete --ignore-not-found \
     deployment/test-app-summon-init \
     service/test-app-summon-init \
-    serviceaccount/test-app-summon-init
+    serviceaccount/test-app-summon-init \
+    serviceaccount/oc-test-app-summon-init
 
   if [ $PLATFORM = 'openshift' ]; then
     oc delete --ignore-not-found deploymentconfig/test-app-summon-init

--- a/bootstrap.env
+++ b/bootstrap.env
@@ -1,2 +1,4 @@
 # These values augment those set in ...-deploy bootstrap.env
-export TEST_APP_NAMESPACE_NAME=amex
+export TEST_APP_NAMESPACE_NAME=[choose the namespace to deploy your apps to]
+export CONJUR_ACCOUNT=[Conjur account]
+export CONJUR_ADMIN_PASSWORD=[password of Conjur admin user]

--- a/policy/load_policies.sh
+++ b/policy/load_policies.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -eo pipefail
+
+if [ "$CONJUR_APPLIANCE_URL" != "" ]; then
+  conjur init -u $CONJUR_APPLIANCE_URL -a $CONJUR_ACCOUNT
+fi
+
+# check for unset vars after checking for appliance url
+set -u
+
+conjur authn login -u admin -p $CONJUR_ADMIN_PASSWORD
+
+readonly POLICY_FILES=(
+  "policy/users.yml"
+  "policy/generated/project-authn.yml"
+  "policy/generated/cluster-authn-svc.yml"
+  "policy/generated/app-identity.yml"
+  "policy/app-access.yml"
+)
+
+for policy_file in "${POLICY_FILES[@]}"; do
+  echo "Loading policy $policy_file..."
+  if [[ "$CONJUR_VERSION" == "4" ]]; then
+    conjur policy load --as-group security_admin $policy_file
+  elif [[ "$CONJUR_VERSION" == "5" ]]; then
+    conjur policy load root $policy_file
+  fi
+done
+
+# load secret values for each app
+readonly APPS=(
+  "test-summon-init-app"
+  "test-summon-sidecar-app"
+  "test-secretless-app"
+)
+
+for app_name in "${APPS[@]}"; do
+  echo "Loading secret values for $app_name"
+  conjur variable values add "$app_name-db/password" $DB_PASSWORD
+  conjur variable values add "$app_name-db/username" "test_app"
+
+  db_url="$app_name-backend.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:5432/postgres"
+
+  if [[ "$app_name" = "test-secretless-app" ]]; then
+    # Secretless doesn't require the full connection URL, just the host/port
+    # and an optional database
+    conjur variable values add "$app_name-db/url" "$db_url"
+  else
+    conjur variable values add "$app_name-db/url" "postgresql://$db_url"
+  fi
+done
+
+conjur authn logout

--- a/set_env_vars.sh
+++ b/set_env_vars.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Set the default values of environment variables used by the scripts
+CONJUR_VERSION=${CONJUR_VERSION:-$CONJUR_MAJOR_VERSION} # default to CONJUR_MAJOR_VERSION if not set
+PLATFORM="${PLATFORM:-kubernetes}"  # default to kubernetes if env var not set
+
+MINIKUBE="${MINIKUBE:-false}"
+MINISHIFT="${MINISHIFT:-false}"
+
+LOCAL_AUTHENTICATOR="${LOCAL_AUTHENTICATOR:-false}"
+DEPLOY_MASTER_CLUSTER="${DEPLOY_MASTER_CLUSTER:-false}"
+
+DOCKER_EMAIL="${DOCKER_EMAIL:-}"

--- a/start
+++ b/start
@@ -1,13 +1,21 @@
 #!/bin/bash
 set -xeuo pipefail
 
+. set_env_vars.sh
+
 ./0_check_dependencies.sh
 
 ./stop
 
 ./1_create_test_app_namespace.sh
-./2_load_conjur_policies.sh
-./3_init_conjur_cert_authority.sh
+
+if [[ "${DEPLOY_MASTER_CLUSTER}" = "true" ]]; then
+  # Only automatically run these scripts for dev/demo envs deploying a master
+  # cluster directly to k8s/oc
+  ./2_load_conjur_policies.sh
+  ./3_init_conjur_cert_authority.sh
+fi
+
 ./4_store_conjur_cert.sh
 ./5_build_and_push_containers.sh
 ./6_deploy_test_app.sh

--- a/utils.sh
+++ b/utils.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 
-CONJUR_VERSION=${CONJUR_VERSION:-$CONJUR_MAJOR_VERSION} # default to CONJUR_MAJOR_VERSION if not set
-PLATFORM="${PLATFORM:-kubernetes}"  # default to kubernetes if env var not set
-
-MINIKUBE="${MINIKUBE:-false}"
-MINISHIFT="${MINISHIFT:-false}"
-LOCAL_AUTHENTICATOR="${LOCAL_AUTHENTICATOR:-false}"
+. set_env_vars.sh
 
 if [ $PLATFORM = 'kubernetes' ]; then
     cli=kubectl
@@ -16,10 +11,15 @@ fi
 check_env_var() {
   var_name=$1
 
+  # temporarily turn off checking for unset variables
+  set +u
+
   if [ "${!var_name}" = "" ]; then
     echo "You must set $1 before running these scripts."
     exit 1
   fi
+
+  set -u
 }
 
 announce() {


### PR DESCRIPTION
- Separate env var default setting into its own script that can be imported in
  start and utils.sh
- Augment existing bootstrap.env
- Update README with instructions for standard (only followers in k8s) flow,
  with the master-in-k8s flow as a special case
- Add a convenience script to enable loading the demo policies in a CLI
  container connected to a remote master

Connected to conjurinc/appliance#606

Verified master+followers flow and follower-only flow in GKE and OC 3.9