### PR TITLE
add support for openshift ci

### DIFF
--- a/6_deploy_test_app.sh
+++ b/6_deploy_test_app.sh
@@ -60,7 +60,7 @@ init_connection_specs() {
     authenticator_client_image=$(platform_image conjur-authn-k8s-client)
     secretless_image=$(platform_image secretless-broker)
   else
-    authenticator_client_image="cyberark/conjur-kubernetes-authenticator:0.11.1"
+    authenticator_client_image="cyberark/conjur-kubernetes-authenticator"
     secretless_image="cyberark/secretless-broker"
   fi
 

--- a/6_deploy_test_app.sh
+++ b/6_deploy_test_app.sh
@@ -60,7 +60,7 @@ init_connection_specs() {
     authenticator_client_image=$(platform_image conjur-authn-k8s-client)
     secretless_image=$(platform_image secretless-broker)
   else
-    authenticator_client_image="cyberark/conjur-kubernetes-authenticator"
+    authenticator_client_image="cyberark/conjur-kubernetes-authenticator:0.11.1"
     secretless_image="cyberark/secretless-broker"
   fi
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,18 @@ pipeline {
             sh 'cd ci && summon -e gke ./test gke 5'
           }
         }
+
+        stage('OpenShift v3.9 and v4 Conjur') {
+          steps {
+            sh 'cd ci && summon -e oc ./test oc 4'
+          }
+        }
+
+        stage('OpenShift v3.9 and v5 Conjur') {
+          steps {
+            sh 'cd ci && summon -e oc ./test oc 5'
+          }
+        }
       }
     }
   }

--- a/ci/secrets.yml
+++ b/ci/secrets.yml
@@ -25,9 +25,13 @@ oc:
   GCLOUD_PROJECT_NAME: ""
   GCLOUD_SERVICE_KEY: ""
 
-  OPENSHIFT_URL: master.openshift37.itci.conjur.net:8443
-  OPENSHIFT_USERNAME: admin
-  OPENSHIFT_PASSWORD: !var ci/openshift37/users/admin/password
+  OPENSHIFT_URL: !var ci/openshift/3.9/hostname
+  OPENSHIFT_USERNAME: !var ci/openshift/3.9/username
+  OPENSHIFT_PASSWORD: !var ci/openshift/3.9/password
+  OSHIFT_CLUSTER_ADMIN_USERNAME: !var ci/openshift/3.9/username
+  OSHIFT_CONJUR_ADMIN_USERNAME: !var ci/openshift/3.9/username
 
   PLATFORM: openshift
-  DOCKER_REGISTRY_PATH: docker-registry-default.apps.openshift37.itci.conjur.net
+  DOCKER_REGISTRY_URL: !var ci/openshift/3.9/hostname
+  DOCKER_REGISTRY_PATH: !var ci/openshift/3.9/hostname
+  OPENSHIFT_CLI_URL: https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz

--- a/ci/test
+++ b/ci/test
@@ -135,6 +135,7 @@ function deleteRegistryImage() {
 
 function runDockerCommand() {
   docker run --rm \
+    -it \
     -e CONJUR_VERSION \
     -e CONJUR_APPLIANCE_IMAGE \
     -e CONJUR_NAMESPACE_NAME \

--- a/ci/test
+++ b/ci/test
@@ -71,7 +71,7 @@ function main() {
 
 function deployConjur() {
   pushd ..
-    git clone --single-branch --branch works-in-oc git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
+    git clone git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
   popd
 
   runDockerCommand "cd kubernetes-conjur-deploy-$UNIQUE_TEST_ID && ./start"

--- a/ci/test
+++ b/ci/test
@@ -50,6 +50,11 @@ CONJUR_VERSION="$2"
 export TEST_PLATFORM
 export CONJUR_VERSION
 
+# sensible default for OPENSHIFT_URL port
+if [[ ! -z "${OPENSHIFT_URL}" ]] && [[ "${OPENSHIFT_URL}" != *: ]]; then
+ OPENSHIFT_URL="${OPENSHIFT_URL}:8443"
+fi
+
 function main() {
   announce 'Checking arguments'
   checkArguments
@@ -149,6 +154,8 @@ function runDockerCommand() {
     -e OPENSHIFT_URL \
     -e OPENSHIFT_USERNAME \
     -e OPENSHIFT_PASSWORD \
+    -e OSHIFT_CONJUR_ADMIN_USERNAME \
+    -e OSHIFT_CLUSTER_ADMIN_USERNAME \
     -v $GCLOUD_SERVICE_KEY:/tmp$GCLOUD_SERVICE_KEY \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v ~/.config:/root/.config \

--- a/ci/test
+++ b/ci/test
@@ -71,7 +71,7 @@ function main() {
 
 function deployConjur() {
   pushd ..
-    git clone git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
+    git clone --single-branch --branch works-in-oc git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
   popd
 
   runDockerCommand "cd kubernetes-conjur-deploy-$UNIQUE_TEST_ID && ./start"

--- a/ci/test
+++ b/ci/test
@@ -135,7 +135,7 @@ function deleteRegistryImage() {
 
 function runDockerCommand() {
   docker run --rm \
-    -it \
+    -i \
     -e CONJUR_VERSION \
     -e CONJUR_APPLIANCE_IMAGE \
     -e CONJUR_NAMESPACE_NAME \

--- a/policy/templates/project-authn-def.template.yml
+++ b/policy/templates/project-authn-def.template.yml
@@ -15,6 +15,7 @@
       annotations:
         kubernetes/authentication-container-name: authenticator
         openshift: "true"
+
     - !host
       id: {{ TEST_APP_NAMESPACE_NAME }}/service_account/test-app-summon-sidecar
       annotations:
@@ -26,6 +27,12 @@
         kubernetes/authentication-container-name: authenticator
         kubernetes: "true"
     - !host
+      id: {{ TEST_APP_NAMESPACE_NAME }}/service_account/test-app-secretless
+      annotations:
+        kubernetes/authentication-container-name: secretless
+        kubernetes: "true"
+
+    - !host
       id: {{ TEST_APP_NAMESPACE_NAME }}/service_account/oc-test-app-summon-sidecar
       annotations:
         kubernetes/authentication-container-name: authenticator
@@ -35,18 +42,11 @@
       annotations:
         kubernetes/authentication-container-name: authenticator
         openshift: "true"
-
-    - !host
-      id: {{ TEST_APP_NAMESPACE_NAME }}/service_account/test-app-secretless
-      annotations:
-        kubernetes/authentication-container-name: secretless
-        kubernetes: "true"
-
     - !host
       id: {{ TEST_APP_NAMESPACE_NAME }}/service_account/oc-test-app-secretless
       annotations:
         kubernetes/authentication-container-name: secretless
-        kubernetes: "true"
+        openshift: "true"
 
   - !grant
     role: !layer

--- a/utils.sh
+++ b/utils.sh
@@ -168,6 +168,6 @@ function service_ip() {
 function deployment_status() {
   local deployment=$1
 
-  echo "$($cli describe deploymentconfig $deployment | grep '^\tStatus:' |
+  echo "$($cli describe deploymentconfig $deployment | awk '/^\tStatus:/' |
     awk '{ print $2 }')"
 }


### PR DESCRIPTION
Adds support for running CI tests for OpenShift
Resolves #43 

TODO: rollback tempfix commits once
- [x] ~~authenticator is fixed (https://github.com/cyberark/conjur-authn-k8s-client/pull/15)~~
- [x] ~kubernetes-conjur-deploy fixes for OpenShift are merged (https://github.com/cyberark/kubernetes-conjur-deploy/pull/47)~