### PR TITLE
cleanup ensure_env_database

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -19,12 +19,13 @@ check_env_var() {
 
 ensure_env_database() {
   local valid_dbs=(
-    postgres
-    mysql
+  'postgres'
+  'mysql'
   )
-  if ! printf '%s\n' "${valid_dbs[@]}" | grep -q "^${TEST_APP_DATABASE}\$"; then
-    echo "Got '${TEST_APP_DATABASE}', expected TEST_APP_DATABASE to be one of:"
-    printf "'%s'\n" "${valid_dbs[@]}"
+
+  if ! printf '%s\n' "${valid_dbs[@]}" | grep -Fxq "${TEST_APP_DATABASE}"; then
+    echo "Got '${TEST_APP_DATABASE}', expected TEST_APP_DATABASE to be one of:";
+    printf "'%s'\n" "${valid_dbs[@]}";
     exit 1
   fi
 }


### PR DESCRIPTION
It's not clear why but occasionally the previous form would result in a failed build with the message:
```
Got 'postgres', expected TEST_APP_DATABASE to be one of:
'postgres'
'mysql'
```
This suggested the condition check logic might be flawed.