### PR TITLE
Fix broken script use for non-master deployments

### DIFF
--- a/0_check_dependencies.sh
+++ b/0_check_dependencies.sh
@@ -6,12 +6,17 @@ set -eo pipefail
 check_env_var "CONJUR_VERSION"
 check_env_var "CONJUR_NAMESPACE_NAME"
 check_env_var "TEST_APP_NAMESPACE_NAME"
-[[ "$PLATFORM" == "kubernetes" ]] && check_env_var "DOCKER_REGISTRY_URL"
+
+if [[ "$PLATFORM" == "kubernetes" ]]; then
+  check_env_var "DOCKER_REGISTRY_URL"
+fi
+
 check_env_var "DOCKER_REGISTRY_PATH"
 check_env_var "CONJUR_ACCOUNT"
 check_env_var "CONJUR_ADMIN_PASSWORD"
 check_env_var "AUTHENTICATOR_ID"
 check_env_var "TEST_APP_DATABASE"
+
 ensure_env_database
 
 export DEPLOY_MASTER_CLUSTER="${DEPLOY_MASTER_CLUSTER:-false}"

--- a/0_check_dependencies.sh
+++ b/0_check_dependencies.sh
@@ -13,3 +13,11 @@ check_env_var "CONJUR_ADMIN_PASSWORD"
 check_env_var "AUTHENTICATOR_ID"
 check_env_var "TEST_APP_DATABASE"
 ensure_env_database
+
+export DEPLOY_MASTER_CLUSTER="${DEPLOY_MASTER_CLUSTER:-false}"
+if [[ "$DEPLOY_MASTER_CLUSTER" != "true" ]]; then
+  error_message="Manual policy creation/loading must be done before running './start' when "
+  error_message+="not deploying a master cluster!"
+  check_file_exists "./$PLATFORM/tmp.${TEST_APP_NAMESPACE_NAME}.postgres.yml" "${error_message}"
+  check_file_exists "./$PLATFORM/tmp.${TEST_APP_NAMESPACE_NAME}.mysql.yml" "${error_message}"
+fi

--- a/stop
+++ b/stop
@@ -3,11 +3,6 @@ set -euo pipefail
 
 . utils.sh
 
-set_namespace $TEST_APP_NAMESPACE_NAME
-$cli get pods
-
-set_namespace default
-
 if [[ $PLATFORM == openshift ]]; then
   oc login -u $OSHIFT_CLUSTER_ADMIN_USERNAME
 fi
@@ -17,8 +12,8 @@ if has_namespace $TEST_APP_NAMESPACE_NAME; then
 
   printf "Waiting for $TEST_APP_NAMESPACE_NAME namespace deletion to complete"
 
-  while : ; do
-    printf "."
+  while true; do
+    printf '.'
 
     if has_namespace "$TEST_APP_NAMESPACE_NAME"; then
       sleep 5

--- a/utils.sh
+++ b/utils.sh
@@ -17,6 +17,20 @@ check_env_var() {
   fi
 }
 
+check_file_exists() {
+  local file_path="$1"
+  local error_message="$2"
+
+  if [[ ! -r "${file_path}" ]]; then
+    echo "ERROR: File '${file_path}' not found!"
+    if [[ "${error_message}" != "" ]]; then
+      echo "ERROR: ${error_message}"
+    fi
+
+    exit 1
+  fi
+}
+
 ensure_env_database() {
   local valid_dbs=(
   'postgres'


### PR DESCRIPTION
Old code would error out deploying the database since templates weren't
properly made. We now ensure that we create the templates in both cases
though obviously the follower-deploy policy loading is left to the user
to properly do with the right policies.

Connected to #57 