### PR TITLE
Ensure that MINI_ENV variable has variable value set

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -151,6 +151,8 @@ function wait_for_it() {
 }
 
 function is_minienv() {
+  MINI_ENV="${MINI_ENV:-false}"
+
   if hash minishift 2>/dev/null; then
     # Check if Minishift is running too
     if [[ "$MINI_ENV" == "false" ]] && [[ "$(minishift status | grep Running)" = "" ]]; then


### PR DESCRIPTION
Either deploy nor demo explicitly need to set this variable so in
non-minienv cases this util class will fail. This fix ensures that we
assume that minienv is false when it's not set.