### PR TITLE
Limit retries in 7_verify_auth loops

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bash-lib"]
+	path = bash-lib
+	url = https://github.com/cyberark/bash-lib

--- a/start
+++ b/start
@@ -2,6 +2,8 @@
 set -xeuo pipefail
 
 . set_env_vars.sh
+. utils.sh
+init_bash_lib
 
 ./0_check_dependencies.sh
 

--- a/utils.sh
+++ b/utils.sh
@@ -8,6 +8,12 @@ elif [ $PLATFORM = 'openshift' ]; then
     cli=oc
 fi
 
+init_bash_lib() {
+  git submodule update --init --recursive
+  bash_lib="$(dirname "${BASH_SOURCE[0]}")/bash-lib"
+  . "${bash_lib}/init"
+}
+
 check_env_var() {
   if [[ -z "${!1+x}" ]]; then
 # where ${var+x} is a parameter expansion which evaluates to nothing if var is unset, and substitutes the string x otherwise.


### PR DESCRIPTION
Previously these loops could be infinite if their exit conditions were not
met. This commit introduces the retry function from bash-lib, ensuring
that only a finite number of attempts will be made.

Related: conjurinc/ops#423