### PR TITLE
Fix authentication-container-name annotation value

### DIFF
--- a/policy/templates/authn-any-policy-branch.template.yml
+++ b/policy/templates/authn-any-policy-branch.template.yml
@@ -15,7 +15,7 @@
     - !host
       id: {{ TEST_APP_NAMESPACE_NAME }}/*/*
       annotations:
-        kubernetes/authentication-container-name: cyberark-secrets-provider
+        kubernetes/authentication-container-name: authenticator
         openshift: "true"
 
   - !grant


### PR DESCRIPTION
The annotation value was `cyberark-secrets-provider` while the actual container that the authentication was done from is `authenticator`.