### PR TITLE
Adjust test app database type to be more accurate and have better logging

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -29,9 +29,10 @@ ensure_env_database() {
   'mysql'
   )
 
-  if ! printf '%s\n' "${valid_dbs[@]}" | grep -Fxq "${TEST_APP_DATABASE}"; then
-    echo "Got '${TEST_APP_DATABASE}', expected TEST_APP_DATABASE to be one of:";
-    printf "'%s'\n" "${valid_dbs[@]}";
+  if ! echo "${valid_dbs[@]}" | grep -Eq "\b${TEST_APP_DATABASE}\b"; then
+    printf "TEST_APP_DATABASE value not found in valid_dbs: '%s'\n" "${TEST_APP_DATABASE}"
+    printf "valid_dbs:\n"
+    printf "'%s'\n" "${valid_dbs[@]}"
     exit 1
   fi
 }


### PR DESCRIPTION
This _may_ resolve the intermittent issue where it looked like the string
'postgres' didn't match 'postgres', but should provide a better representation
of the string contents if it doesn't match