### PR TITLE
Use new client image in demo

### DIFF
--- a/6_deploy_test_app.sh
+++ b/6_deploy_test_app.sh
@@ -59,7 +59,7 @@ init_connection_specs() {
     authenticator_client_image=$(platform_image conjur-authn-k8s-client)
     secretless_image=$(platform_image secretless-broker)
   else
-    authenticator_client_image="cyberark/conjur-kubernetes-authenticator"
+    authenticator_client_image="cyberark/conjur-authn-k8s-client"
     secretless_image="cyberark/secretless-broker"
   fi
 


### PR DESCRIPTION
The image name 'conjur-kubernetes-authenticator' is an old one so we should use the new one in our tests.

This requires also a change in the docs so we guide the users to use the new one. PR was already created for this change - https://github.com/cyberark/conjur-docs/pull/708. Please review that as well.