### PR TITLE
Updates to use API v1 instead of v1beta1

### DIFF
--- a/kubernetes/mysql.template.yml
+++ b/kubernetes/mysql.template.yml
@@ -12,7 +12,7 @@ spec:
       targetPort: 3306
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: summon-init-mysql
@@ -58,7 +58,7 @@ spec:
       targetPort: 3306
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: summon-sidecar-mysql
@@ -104,7 +104,7 @@ spec:
       targetPort: 3306
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: secretless-mysql

--- a/kubernetes/postgres.template.yml
+++ b/kubernetes/postgres.template.yml
@@ -12,7 +12,7 @@ spec:
       targetPort: 5432
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: summon-init-pg
@@ -67,7 +67,7 @@ spec:
       targetPort: 5432
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: summon-sidecar-pg
@@ -123,7 +123,7 @@ spec:
       targetPort: 5432
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: secretless-pg

--- a/kubernetes/test-app-conjur-authenticator-role-binding.yml
+++ b/kubernetes/test-app-conjur-authenticator-role-binding.yml
@@ -1,6 +1,6 @@
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1 # TODO: change this to match your k8s version
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: test-app-conjur-authenticator-role-binding-{{ CONJUR_NAMESPACE_NAME }}
   namespace: {{ TEST_APP_NAMESPACE_NAME }}

--- a/kubernetes/test-app-secretless.yml
+++ b/kubernetes/test-app-secretless.yml
@@ -18,7 +18,7 @@ kind: ServiceAccount
 metadata:
   name: test-app-secretless
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/kubernetes/test-app-summon-init.yml
+++ b/kubernetes/test-app-summon-init.yml
@@ -18,7 +18,7 @@ kind: ServiceAccount
 metadata:
   name: test-app-summon-init
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/kubernetes/test-app-summon-sidecar.yml
+++ b/kubernetes/test-app-summon-sidecar.yml
@@ -18,7 +18,7 @@ kind: ServiceAccount
 metadata:
   name: test-app-summon-sidecar
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/kubernetes/test-app-with-host-outside-apps-branch-summon-init.yml
+++ b/kubernetes/test-app-with-host-outside-apps-branch-summon-init.yml
@@ -19,7 +19,7 @@ kind: ServiceAccount
 metadata:
   name: test-app-with-host-outside-apps-branch-summon-init
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/openshift/mysql.template.yml
+++ b/openshift/mysql.template.yml
@@ -12,7 +12,7 @@ spec:
       targetPort: 3306
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: summon-init-mysql
@@ -56,7 +56,7 @@ spec:
       targetPort: 3306
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: summon-sidecar-mysql
@@ -100,7 +100,7 @@ spec:
       targetPort: 3306
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: secretless-mysql

--- a/openshift/postgres.template.yml
+++ b/openshift/postgres.template.yml
@@ -12,7 +12,7 @@ spec:
       targetPort: 5432
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: summon-init-pg
@@ -69,7 +69,7 @@ spec:
       targetPort: 5432
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: summon-sidecar-pg
@@ -126,7 +126,7 @@ spec:
       targetPort: 5432
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: secretless-pg

--- a/openshift/test-app-conjur-authenticator-role-binding.yml
+++ b/openshift/test-app-conjur-authenticator-role-binding.yml
@@ -1,6 +1,6 @@
 ---
 kind: RoleBinding
-apiVersion: v1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: test-app-conjur-authenticator-role-binding-{{ CONJUR_NAMESPACE_NAME }}
   namespace: {{ TEST_APP_NAMESPACE_NAME }}
@@ -9,5 +9,6 @@ subjects:
     name: conjur-cluster
     namespace: {{ CONJUR_NAMESPACE_NAME }}
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: conjur-authenticator-{{ CONJUR_NAMESPACE_NAME }}


### PR DESCRIPTION
Based on the Secretless MSSQL XA (cyberark/secretless-broker#977) we have a recommended update to the API versioning we use in this demo repo / in the docs.

This PR updates the demo flows to use API `v1` instead of `v1beta1`