### PR TITLE
Remove authn k8s client conjur version

### DIFF
--- a/0_check_dependencies.sh
+++ b/0_check_dependencies.sh
@@ -3,7 +3,6 @@ set -eo pipefail
 
 . utils.sh
 
-check_env_var "CONJUR_VERSION"
 check_env_var "CONJUR_NAMESPACE_NAME"
 check_env_var "TEST_APP_NAMESPACE_NAME"
 if [[ "$PLATFORM" == "kubernetes" ]] && ! is_minienv; then

--- a/0_check_dependencies.sh
+++ b/0_check_dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 . utils.sh

--- a/1_create_test_app_namespace.sh
+++ b/1_create_test_app_namespace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 . utils.sh

--- a/2_load_conjur_policies.sh
+++ b/2_load_conjur_policies.sh
@@ -41,7 +41,6 @@ if [[ "${DEPLOY_MASTER_CLUSTER}" == "true" ]]; then
       DB_PASSWORD=${password} \
       TEST_APP_NAMESPACE_NAME=${TEST_APP_NAMESPACE_NAME} \
       TEST_APP_DATABASE=${TEST_APP_DATABASE} \
-      CONJUR_VERSION=${CONJUR_VERSION} \
       /policy/load_policies.sh
     "
 

--- a/2_load_conjur_policies.sh
+++ b/2_load_conjur_policies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 . utils.sh

--- a/3_init_conjur_cert_authority.sh
+++ b/3_init_conjur_cert_authority.sh
@@ -9,10 +9,6 @@ set_namespace $CONJUR_NAMESPACE_NAME
 
 conjur_master=$(get_master_pod_name)
 
-if [ $CONJUR_VERSION = '4' ]; then
-  $cli exec $conjur_master -- conjur-plugin-service authn-k8s rake ca:initialize["conjur/authn-k8s/$AUTHENTICATOR_ID"] > /dev/null
-elif [ $CONJUR_VERSION = '5' ]; then
-  $cli exec $conjur_master -- chpst -u conjur conjur-plugin-service possum rake authn_k8s:ca_init["conjur/authn-k8s/$AUTHENTICATOR_ID"]
-fi
+$cli exec $conjur_master -- chpst -u conjur conjur-plugin-service possum rake authn_k8s:ca_init["conjur/authn-k8s/$AUTHENTICATOR_ID"]
 
 echo "Certificate authority initialized."

--- a/3_init_conjur_cert_authority.sh
+++ b/3_init_conjur_cert_authority.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 . utils.sh

--- a/4_store_conjur_cert.sh
+++ b/4_store_conjur_cert.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 . utils.sh

--- a/5_build_and_push_containers.sh
+++ b/5_build_and_push_containers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 . utils.sh

--- a/6_deploy_test_app.sh
+++ b/6_deploy_test_app.sh
@@ -67,12 +67,7 @@ init_connection_specs() {
   conjur_appliance_url=https://$conjur_follower_name.$CONJUR_NAMESPACE_NAME.svc.cluster.local/api
   conjur_authenticator_url=https://$conjur_follower_name.$CONJUR_NAMESPACE_NAME.svc.cluster.local/api/authn-k8s/$AUTHENTICATOR_ID
 
-  conjur_authn_login_prefix=""
-  if [[ "$CONJUR_VERSION" == "4" ]]; then
-    conjur_authn_login_prefix=$TEST_APP_NAMESPACE_NAME/service_account
-  elif [[ "$CONJUR_VERSION" == "5" ]]; then
-    conjur_authn_login_prefix=host/conjur/authn-k8s/$AUTHENTICATOR_ID/apps/$TEST_APP_NAMESPACE_NAME/service_account
-  fi
+  conjur_authn_login_prefix=host/conjur/authn-k8s/$AUTHENTICATOR_ID/apps/$TEST_APP_NAMESPACE_NAME/service_account
 }
 
 ###########################
@@ -141,7 +136,6 @@ deploy_sidecar_app() {
   sed "s#{{ TEST_APP_DOCKER_IMAGE }}#$test_sidecar_app_docker_image#g" ./$PLATFORM/test-app-summon-sidecar.yml |
     sed "s#{{ AUTHENTICATOR_CLIENT_IMAGE }}#$authenticator_client_image#g" |
     sed "s#{{ IMAGE_PULL_POLICY }}#$IMAGE_PULL_POLICY#g" |
-    sed "s#{{ CONJUR_VERSION }}#$CONJUR_VERSION#g" |
     sed "s#{{ CONJUR_ACCOUNT }}#$CONJUR_ACCOUNT#g" |
     sed "s#{{ CONJUR_AUTHN_LOGIN_PREFIX }}#$conjur_authn_login_prefix#g" |
     sed "s#{{ CONJUR_APPLIANCE_URL }}#$conjur_appliance_url#g" |
@@ -149,7 +143,6 @@ deploy_sidecar_app() {
     sed "s#{{ TEST_APP_NAMESPACE_NAME }}#$TEST_APP_NAMESPACE_NAME#g" |
     sed "s#{{ AUTHENTICATOR_ID }}#$AUTHENTICATOR_ID#g" |
     sed "s#{{ CONFIG_MAP_NAME }}#$TEST_APP_NAMESPACE_NAME#g" |
-    sed "s#{{ CONJUR_VERSION }}#'$CONJUR_VERSION'#g" |
     $cli create -f -
 
   if [[ "$PLATFORM" == "openshift" ]]; then
@@ -178,7 +171,6 @@ deploy_init_container_app() {
   sed "s#{{ TEST_APP_DOCKER_IMAGE }}#$test_init_app_docker_image#g" ./$PLATFORM/test-app-summon-init.yml |
     sed "s#{{ AUTHENTICATOR_CLIENT_IMAGE }}#$authenticator_client_image#g" |
     sed "s#{{ IMAGE_PULL_POLICY }}#$IMAGE_PULL_POLICY#g" |
-    sed "s#{{ CONJUR_VERSION }}#$CONJUR_VERSION#g" |
     sed "s#{{ CONJUR_ACCOUNT }}#$CONJUR_ACCOUNT#g" |
     sed "s#{{ CONJUR_AUTHN_LOGIN_PREFIX }}#$conjur_authn_login_prefix#g" |
     sed "s#{{ CONJUR_APPLIANCE_URL }}#$conjur_appliance_url#g" |
@@ -186,7 +178,6 @@ deploy_init_container_app() {
     sed "s#{{ TEST_APP_NAMESPACE_NAME }}#$TEST_APP_NAMESPACE_NAME#g" |
     sed "s#{{ AUTHENTICATOR_ID }}#$AUTHENTICATOR_ID#g" |
     sed "s#{{ CONFIG_MAP_NAME }}#$TEST_APP_NAMESPACE_NAME#g" |
-    sed "s#{{ CONJUR_VERSION }}#'$CONJUR_VERSION'#g" |
     $cli create -f -
 
   if [[ "$PLATFORM" == "openshift" ]]; then
@@ -217,7 +208,6 @@ deploy_init_container_app_with_host_outside_apps() {
   sed "s#{{ TEST_APP_DOCKER_IMAGE }}#$test_init_app_docker_image#g" ./$PLATFORM/test-app-with-host-outside-apps-branch-summon-init.yml |
     sed "s#{{ AUTHENTICATOR_CLIENT_IMAGE }}#$authenticator_client_image#g" |
     sed "s#{{ IMAGE_PULL_POLICY }}#$IMAGE_PULL_POLICY#g" |
-    sed "s#{{ CONJUR_VERSION }}#$CONJUR_VERSION#g" |
     sed "s#{{ CONJUR_ACCOUNT }}#$CONJUR_ACCOUNT#g" |
     sed "s#{{ CONJUR_AUTHN_LOGIN }}#$conjur_authn_login#g" |
     sed "s#{{ CONJUR_APPLIANCE_URL }}#$conjur_appliance_url#g" |
@@ -225,7 +215,6 @@ deploy_init_container_app_with_host_outside_apps() {
     sed "s#{{ TEST_APP_NAMESPACE_NAME }}#$TEST_APP_NAMESPACE_NAME#g" |
     sed "s#{{ AUTHENTICATOR_ID }}#$AUTHENTICATOR_ID#g" |
     sed "s#{{ CONFIG_MAP_NAME }}#$TEST_APP_NAMESPACE_NAME#g" |
-    sed "s#{{ CONJUR_VERSION }}#'$CONJUR_VERSION'#g" |
     $cli create -f -
 
   if [[ "$PLATFORM" == "openshift" ]]; then
@@ -268,8 +257,7 @@ deploy_secretless_app() {
   esac
   secretless_db_url="$PROTOCOL://localhost:$PORT/test_app"
 
-  sed "s#{{ CONJUR_VERSION }}#$CONJUR_VERSION#g" ./$PLATFORM/test-app-secretless.yml |
-    sed "s#{{ IMAGE_PULL_POLICY }}#$IMAGE_PULL_POLICY#g" |
+  sed "s#{{ IMAGE_PULL_POLICY }}#$IMAGE_PULL_POLICY#g" ./$PLATFORM/test-app-secretless.yml |
     sed "s#{{ SECRETLESS_IMAGE }}#$secretless_image#g" |
     sed "s#{{ SECRETLESS_DB_URL }}#$secretless_db_url#g" |
     sed "s#{{ CONJUR_AUTHN_URL }}#$conjur_authenticator_url#g" |

--- a/6_deploy_test_app.sh
+++ b/6_deploy_test_app.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 . utils.sh

--- a/7_verify_authentication.sh
+++ b/7_verify_authentication.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 . utils.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,25 +18,25 @@ pipeline {
       parallel {
         stage('GKE, v5 Conjur, Postgres') {
           steps {
-            sh 'cd ci && summon --environment gke ./test gke 5 postgres'
+            sh 'cd ci && summon --environment gke ./test gke postgres'
           }
         }
 
         stage('OpenShift v3.9, v5 Conjur, Postgres') {
           steps {
-            sh 'cd ci && summon --environment oc ./test oc 5 postgres'
+            sh 'cd ci && summon --environment oc ./test oc postgres'
           }
         }
 
         stage('OpenShift v3.10, v5 Conjur, Postgres') {
           steps {
-            sh 'cd ci && summon --environment oc310 ./test oc 5 postgres'
+            sh 'cd ci && summon --environment oc310 ./test oc postgres'
           }
         }
 
         stage('OpenShift v3.11, v5 Conjur, Postgres') {
           steps {
-            sh 'cd ci && summon --environment oc311 ./test oc 5 postgres'
+            sh 'cd ci && summon --environment oc311 ./test oc postgres'
           }
         }
       }
@@ -47,25 +47,25 @@ pipeline {
       parallel {
         stage('GKE, v5 Conjur, MySQL') {
           steps {
-            sh 'cd ci && summon --environment gke ./test gke 5 mysql'
+            sh 'cd ci && summon --environment gke ./test gke mysql'
           }
         }
 
         stage('OpenShift v3.9, v5 Conjur, MySQL') {
           steps {
-            sh 'cd ci && summon --environment oc ./test oc 5 mysql'
+            sh 'cd ci && summon --environment oc ./test oc mysql'
           }
         }
 
         stage('OpenShift v3.10, v5 Conjur, MySQL') {
           steps {
-            sh 'cd ci && summon --environment oc310 ./test oc 5 mysql'
+            sh 'cd ci && summon --environment oc310 ./test oc mysql'
           }
         }
 
         stage('OpenShift v3.11, v5 Conjur, MySQL') {
           steps {
-            sh 'cd ci && summon --environment oc311 ./test oc 5 mysql'
+            sh 'cd ci && summon --environment oc311 ./test oc mysql'
           }
         }
       }

--- a/README.md
+++ b/README.md
@@ -4,20 +4,9 @@ This repo demonstrates an app retrieving secrets from a Conjur cluster running
 in Kubernetes or OpenShift. The numbered scripts perform the same steps that a
 user has to go through when setting up their own applications.
 
-**Note:** These demo scripts have only been tested with Conjur v4 and v5
-Enterprise. Conjur OSS is not yet supported.
+**Note:** These demo scripts have only been tested with Dynamic Access Provider v10+. Older versions of Conjur Enterprise v4 and Conjur OSS are not supported.
 
 # Setup
-
-### Conjur Version
-
-If you are working with Conjur v4, you will need to set:
-
-```
-export CONJUR_VERSION=4
-```
-
-Otherwise, this variable will default to `5`.
 
 ### Platform
 
@@ -121,7 +110,7 @@ $ docker run \
     -e CONJUR_ACCOUNT=$CONJUR_ACCOUNT \
     -e CONJUR_AUTHN_LOGIN="admin" \
     -e CONJUR_ADMIN_PASSWORD=$CONJUR_ADMIN_PASSWORD \
-    -e CONJUR_VERSION=$CONJUR_VERSION \
+    -e CONJUR_VERSION=5 \
     -e TEST_APP_NAMESPACE_NAME=$TEST_APP_NAMESPACE_NAME \
     cyberark/conjur-cli:5
 

--- a/ci/platform_login
+++ b/ci/platform_login
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 IFS=$'\n\t'

--- a/ci/test
+++ b/ci/test
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
 
 # Usage:
-# ./test [platform] [conjur version] [database]
+# ./test [platform] [database]
 #
 # Note: This script expects several environment variables to be
 # defined and exported, some of which are sensitive/secret values.
 # It is for this that we recommend to always call this script using summon.
 #
 # Recommended usage:
-# summon --environment [platform] ./test [platform] [conjur version] [database]
+# summon --environment [platform] ./test [platform] [database]
 #
 # platform: gke or oc
-# conjur version: 4 or 5
 # database: postgres or mysql
 
 set -euo pipefail
@@ -40,15 +39,14 @@ trap finish EXIT
 function printUsage() {
   echo "---"
   echo "Usage:"
-  echo "./test [platform] [conjur version] [database]"
+  echo "./test [platform] [database]"
   echo ""
   echo "Note: This script expects several environment variables to be defined and exported, some of which are sensitive/secret values. It is for this that we recommend to always call this script using summon."
   echo ""
   echo "Recommended Usage:"
-  echo "summon --environment [platform] ./test [platform] [conjur version] [database]"
+  echo "summon --environment [platform] ./test [platform] [database]"
   echo ""
   echo "platform: gke or oc"
-  echo "conjur version: 4 or 5"
   echo "database: postgres or mysql"
 
   exit 1
@@ -88,21 +86,19 @@ function prepareTestEnvironment() {
 
   export UNIQUE_TEST_ID="$(uuidgen | tr "[:upper:]" "[:lower:]" | head -c 10)"
 
-  export CONJUR_NAMESPACE_NAME=conjur-$CONJUR_VERSION-$UNIQUE_TEST_ID-test
-  export AUTHENTICATOR_ID=conjur-$CONJUR_VERSION-$UNIQUE_TEST_ID-test
-  export TEST_APP_NAMESPACE_NAME=test-app-$CONJUR_VERSION-$UNIQUE_TEST_ID
+  export CONJUR_NAMESPACE_NAME=conjur-5-$UNIQUE_TEST_ID-test
+  export AUTHENTICATOR_ID=conjur-5-$UNIQUE_TEST_ID-test
+  export TEST_APP_NAMESPACE_NAME=test-app-5-$UNIQUE_TEST_ID
+
+  export CONJUR_VERSION=5 # still required by kubernetes-conjur-deploy
 
   export DEPLOY_MASTER_CLUSTER=true
 
   export MINI_ENV=false
 
-  export CONJUR_DEMO_TEST_IMAGE=conjur-demo-$CONJUR_VERSION-$UNIQUE_TEST_ID
+  export CONJUR_DEMO_TEST_IMAGE=conjur-demo-5-$UNIQUE_TEST_ID
 
-  if [[ "$CONJUR_VERSION" = "4" ]]; then
-    export CONJUR_APPLIANCE_IMAGE=$registry:4.9-stable
-  else
-    export CONJUR_APPLIANCE_IMAGE=$registry:5.0-stable
-  fi
+  export CONJUR_APPLIANCE_IMAGE=$registry:5.0-stable
 
   # Prepare Docker images
   docker pull $CONJUR_APPLIANCE_IMAGE
@@ -180,9 +176,7 @@ function announce() {
 # Check that the argument values are valid
 function checkArguments() {
   if [[ "$TEST_PLATFORM" != "gke" && "$TEST_PLATFORM" != "oc" ]]; then
-    echo "The only valid platform values are 'gke' and 'oc'"
-  elif [[ "$CONJUR_VERSION" != "4" && "$CONJUR_VERSION" != "5" ]]; then
-    echo "The only valid Conjur version values are '4' and '5'."
+   echo "The only valid platform values are 'gke' and 'oc'"
   else
     return 0
   fi
@@ -191,17 +185,15 @@ function checkArguments() {
 }
 
 # Parse input arguments
-if [[ $# -ne 3 ]]; then
+if [[ $# -ne 2 ]]; then
   echo "Invalid number of arguments."
   printUsage
 fi
 
 TEST_PLATFORM="$1"
-CONJUR_VERSION="$2"
-TEST_APP_DATABASE="$3"
+TEST_APP_DATABASE="$2"
 
 export TEST_PLATFORM
-export CONJUR_VERSION
 export TEST_APP_DATABASE
 
 # sensible default for OPENSHIFT_URL port

--- a/ci/test
+++ b/ci/test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage:
 # ./test [platform] [conjur version] [database]

--- a/delete_deployments.sh
+++ b/delete_deployments.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/usr/bin/env bash
 set -eo pipefail
 
 . utils.sh

--- a/exec-into-cli.sh
+++ b/exec-into-cli.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . utils.sh
 set_namespace $CONJUR_NAMESPACE_NAME
 conjur_cli_pod=$(get_conjur_cli_pod_name)

--- a/kubernetes/test-app-secretless.yml
+++ b/kubernetes/test-app-secretless.yml
@@ -59,7 +59,7 @@ spec:
         - containerPort: 5432
         env:
           - name: CONJUR_VERSION
-            value: '{{ CONJUR_VERSION }}'
+            value: "5"
           - name: MY_POD_NAME
             valueFrom:
               fieldRef:

--- a/kubernetes/test-app-summon-init.yml
+++ b/kubernetes/test-app-summon-init.yml
@@ -50,7 +50,7 @@ spec:
           timeoutSeconds: 5
         env:
           - name: CONJUR_VERSION
-            value: '{{ CONJUR_VERSION }}'
+            value: "5"
           - name: CONJUR_APPLIANCE_URL
             value: "{{ CONJUR_APPLIANCE_URL }}"
           - name: CONJUR_ACCOUNT
@@ -71,8 +71,6 @@ spec:
         imagePullPolicy: Always
         name: authenticator
         env:
-          - name: CONJUR_VERSION
-            value: '{{ CONJUR_VERSION }}'
           - name: CONTAINER_MODE
             value: init
           - name: MY_POD_NAME

--- a/kubernetes/test-app-summon-sidecar.yml
+++ b/kubernetes/test-app-summon-sidecar.yml
@@ -50,7 +50,7 @@ spec:
           timeoutSeconds: 5
         env:
           - name: CONJUR_VERSION
-            value: '{{ CONJUR_VERSION }}'
+            value: "5"
           - name: CONJUR_APPLIANCE_URL
             value: "{{ CONJUR_APPLIANCE_URL }}"
           - name: CONJUR_ACCOUNT
@@ -70,8 +70,6 @@ spec:
         imagePullPolicy: Always
         name: authenticator
         env:
-          - name: CONJUR_VERSION
-            value: '{{ CONJUR_VERSION }}'
           - name: CONTAINER_MODE
             value: sidecar
           - name: MY_POD_NAME

--- a/kubernetes/test-app-with-host-outside-apps-branch-summon-init.yml
+++ b/kubernetes/test-app-with-host-outside-apps-branch-summon-init.yml
@@ -51,7 +51,7 @@ spec:
           timeoutSeconds: 5
         env:
           - name: CONJUR_VERSION
-            value: '{{ CONJUR_VERSION }}'
+            value: "5"
           - name: CONJUR_APPLIANCE_URL
             value: "{{ CONJUR_APPLIANCE_URL }}"
           - name: CONJUR_ACCOUNT
@@ -86,8 +86,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: CONJUR_VERSION
-            value: '{{ CONJUR_VERSION }}'
           - name: CONJUR_APPLIANCE_URL
             value: "{{ CONJUR_APPLIANCE_URL }}"
           - name: CONJUR_AUTHN_URL

--- a/openshift/test-app-secretless.yml
+++ b/openshift/test-app-secretless.yml
@@ -59,7 +59,7 @@ spec:
         - containerPort: 5432
         env:
           - name: CONJUR_VERSION
-            value: "{{ CONJUR_VERSION }}"
+            value: "5"
           - name: MY_POD_NAME
             valueFrom:
               fieldRef:

--- a/openshift/test-app-summon-init.yml
+++ b/openshift/test-app-summon-init.yml
@@ -50,7 +50,7 @@ spec:
           timeoutSeconds: 5
         env:
           - name: CONJUR_VERSION
-            value: '{{ CONJUR_VERSION }}'
+            value: "5"
           - name: CONJUR_APPLIANCE_URL
             value: "{{ CONJUR_APPLIANCE_URL }}"
           - name: CONJUR_ACCOUNT
@@ -85,8 +85,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: CONJUR_VERSION
-            value: '{{ CONJUR_VERSION }}'
           - name: CONJUR_APPLIANCE_URL
             value: "{{ CONJUR_APPLIANCE_URL }}"
           - name: CONJUR_AUTHN_URL

--- a/openshift/test-app-summon-sidecar.yml
+++ b/openshift/test-app-summon-sidecar.yml
@@ -50,7 +50,7 @@ spec:
           timeoutSeconds: 5
         env:
           - name: CONJUR_VERSION
-            value: '{{ CONJUR_VERSION }}'
+            value: "5"
           - name: CONJUR_APPLIANCE_URL
             value: "{{ CONJUR_APPLIANCE_URL }}"
           - name: CONJUR_ACCOUNT
@@ -82,8 +82,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: CONJUR_VERSION
-            value: '{{ CONJUR_VERSION }}'
           - name: CONJUR_APPLIANCE_URL
             value: "{{ CONJUR_APPLIANCE_URL }}"
           - name: CONJUR_AUTHN_URL

--- a/openshift/test-app-with-host-outside-apps-branch-summon-init.yml
+++ b/openshift/test-app-with-host-outside-apps-branch-summon-init.yml
@@ -50,7 +50,7 @@ spec:
           timeoutSeconds: 5
         env:
           - name: CONJUR_VERSION
-            value: '{{ CONJUR_VERSION }}'
+            value: "5"
           - name: CONJUR_APPLIANCE_URL
             value: "{{ CONJUR_APPLIANCE_URL }}"
           - name: CONJUR_ACCOUNT
@@ -85,8 +85,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: CONJUR_VERSION
-            value: '{{ CONJUR_VERSION }}'
           - name: CONJUR_APPLIANCE_URL
             value: "{{ CONJUR_APPLIANCE_URL }}"
           - name: CONJUR_AUTHN_URL

--- a/pg/rotate_password
+++ b/pg/rotate_password
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
 new_password="$1"
 if [[ -z $new_password ]]; then

--- a/policy/load_policies.sh
+++ b/policy/load_policies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/policy/load_policies.sh
+++ b/policy/load_policies.sh
@@ -25,11 +25,7 @@ readonly POLICY_FILES=(
 
 for policy_file in "${POLICY_FILES[@]}"; do
   echo "Loading policy $policy_file..."
-  if [[ "$CONJUR_VERSION" == "4" ]]; then
-    conjur policy load --as-group security_admin $policy_file
-  elif [[ "$CONJUR_VERSION" == "5" ]]; then
-    conjur policy load root $policy_file
-  fi
+  conjur policy load root $policy_file
 done
 
 # load secret values for each app

--- a/rotate
+++ b/rotate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 . utils.sh

--- a/set_env_vars.sh
+++ b/set_env_vars.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/set_env_vars.sh
+++ b/set_env_vars.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 # Set the default values of environment variables used by the scripts
-CONJUR_VERSION=${CONJUR_VERSION:-$CONJUR_MAJOR_VERSION} # default to CONJUR_MAJOR_VERSION if not set
 PLATFORM="${PLATFORM:-kubernetes}"  # default to kubernetes if env var not set
 
 MINIKUBE="${MINIKUBE:-false}"

--- a/start
+++ b/start
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -xeuo pipefail
 
 . set_env_vars.sh

--- a/stop
+++ b/stop
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 . utils.sh

--- a/utils.sh
+++ b/utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . set_env_vars.sh
 

--- a/webapp/build.sh
+++ b/webapp/build.sh
@@ -1,2 +1,2 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 docker build -t test-app:$CONJUR_NAMESPACE_NAME .

--- a/webapp/webapp_v5.sh
+++ b/webapp/webapp_v5.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/usr/bin/env bash
 
 # name of secret to retrieve from Conjur
 VAR_ID=test-summon-sidecar-app-db/password


### PR DESCRIPTION
This repo officially only supports DAP v10+ deployments, which use CONJUR_VERSION 5. In this PR, I remove all old CONJUR_VERSION configuration in favor of defaulting to v5 everywhere, to simplify the deployments in line with what we will recommend to customers. We are moving to a model where we use a default `CONJUR_VERSION` of 5 in our products, to simplify the deployment experience of end users.

In this PR, I also update the shebangs in the bash scripts to enable OSX users to run these scripts on their machines, given that bash-lib requires bash v4+.