### PR TITLE
Fixes URL encoding for Kubernetes authentication ID

### DIFF
--- a/0_check_dependencies.sh
+++ b/0_check_dependencies.sh
@@ -17,4 +17,5 @@ check_env_var "CONJUR_ACCOUNT"
 check_env_var "CONJUR_ADMIN_PASSWORD"
 check_env_var "AUTHENTICATOR_ID"
 check_env_var "TEST_APP_DATABASE"
+check_env_var "CONJUR_AUTHN_LOGIN_RESOURCE"
 ensure_env_database

--- a/2_load_conjur_policies.sh
+++ b/2_load_conjur_policies.sh
@@ -10,15 +10,26 @@ pushd policy
 
   # NOTE: generated files are prefixed with the test app namespace to allow for parallel CI
 
+  if [[ "$PLATFORM" == "openshift" ]]; then
+    is_openshift=true
+    is_kubernetes=false
+  else
+    is_openshift=false
+    is_kubernetes=true
+  fi
+
   sed "s#{{ AUTHENTICATOR_ID }}#$AUTHENTICATOR_ID#g" ./templates/cluster-authn-svc-def.template.yml > ./generated/$TEST_APP_NAMESPACE_NAME.cluster-authn-svc.yml
 
   sed "s#{{ AUTHENTICATOR_ID }}#$AUTHENTICATOR_ID#g" ./templates/project-authn-def.template.yml |
+    sed "s#{{ IS_OPENSHIFT }}#$is_openshift#g" |
+    sed "s#{{ IS_KUBERNETES }}#$is_kubernetes#g" |
     sed "s#{{ TEST_APP_NAMESPACE_NAME }}#$TEST_APP_NAMESPACE_NAME#g" > ./generated/$TEST_APP_NAMESPACE_NAME.project-authn.yml
 
   sed "s#{{ AUTHENTICATOR_ID }}#$AUTHENTICATOR_ID#g" ./templates/app-identity-def.template.yml |
     sed "s#{{ TEST_APP_NAMESPACE_NAME }}#$TEST_APP_NAMESPACE_NAME#g" > ./generated/$TEST_APP_NAMESPACE_NAME.app-identity.yml
 
   sed "s#{{ AUTHENTICATOR_ID }}#$AUTHENTICATOR_ID#g" ./templates/authn-any-policy-branch.template.yml |
+    sed "s#{{ IS_OPENSHIFT }}#$is_openshift#g" |
     sed "s#{{ TEST_APP_NAMESPACE_NAME }}#$TEST_APP_NAMESPACE_NAME#g" > ./generated/$TEST_APP_NAMESPACE_NAME.authn-any-policy-branch.yml
 popd
 

--- a/6_deploy_test_app.sh
+++ b/6_deploy_test_app.sh
@@ -6,6 +6,8 @@ set -eo pipefail
 main() {
   announce "Deploying test apps for $TEST_APP_NAMESPACE_NAME."
 
+  URLENCODED_AUTHN_ID=$(urlencode $AUTHENTICATOR_ID)
+
   set_namespace $TEST_APP_NAMESPACE_NAME
   init_registry_creds
   init_connection_specs
@@ -65,9 +67,9 @@ init_connection_specs() {
 
   conjur_follower_name=${CONJUR_FOLLOWER_NAME:-conjur-follower}
   conjur_appliance_url=https://$conjur_follower_name.$CONJUR_NAMESPACE_NAME.svc.cluster.local/api
-  conjur_authenticator_url=https://$conjur_follower_name.$CONJUR_NAMESPACE_NAME.svc.cluster.local/api/authn-k8s/$AUTHENTICATOR_ID
+  conjur_authenticator_url=https://$conjur_follower_name.$CONJUR_NAMESPACE_NAME.svc.cluster.local/api/authn-k8s/$URLENCODED_AUTHN_ID
 
-  conjur_authn_login_prefix=host/conjur/authn-k8s/$AUTHENTICATOR_ID/apps/$TEST_APP_NAMESPACE_NAME/service_account
+  conjur_authn_login_prefix=host/conjur/authn-k8s/$AUTHENTICATOR_ID/apps/$TEST_APP_NAMESPACE_NAME/$CONJUR_AUTHN_LOGIN_RESOURCE
 }
 
 ###########################

--- a/README.md
+++ b/README.md
@@ -49,7 +49,18 @@ export CONJUR_ADMIN_PASSWORD=<admin-password>
 export AUTHENTICATOR_ID=<service-id>
 ```
 
-and optionally (if using a private Docker registry):
+If you would like your applications to use a deployment name as an
+authentication identity when authenticating with Kubernetes (as opposed to
+using service account name), then set the following:
+
+```
+export CONJUR_AUTHN_LOGIN_RESOURCE=deployment
+```
+Otherwise, this variable will default to `service_account`, and the service
+account name will be used when authenticating your application with
+Kubernetes.
+
+Also, if using a private Docker registry:
 
 ```
 export DOCKER_USERNAME=<your-username>
@@ -111,6 +122,7 @@ $ docker run \
     -e CONJUR_AUTHN_LOGIN="admin" \
     -e CONJUR_ADMIN_PASSWORD=$CONJUR_ADMIN_PASSWORD \
     -e CONJUR_VERSION=5 \
+    -e TEST_APP_DATABASE=$TEST_APP_DATABASE \
     -e TEST_APP_NAMESPACE_NAME=$TEST_APP_NAMESPACE_NAME \
     cyberark/conjur-cli:5
 

--- a/policy/templates/authn-any-policy-branch.template.yml
+++ b/policy/templates/authn-any-policy-branch.template.yml
@@ -16,7 +16,7 @@
       id: {{ TEST_APP_NAMESPACE_NAME }}/*/*
       annotations:
         kubernetes/authentication-container-name: authenticator
-        openshift: "true"
+        openshift: "{{ IS_OPENSHIFT }}"
 
   - !grant
     role: !layer

--- a/policy/templates/project-authn-def.template.yml
+++ b/policy/templates/project-authn-def.template.yml
@@ -14,39 +14,69 @@
       id: {{ TEST_APP_NAMESPACE_NAME }}/*/*
       annotations:
         kubernetes/authentication-container-name: authenticator
-        openshift: "true"
+        openshift: "{{ IS_OPENSHIFT }}"
 
     - !host
       id: {{ TEST_APP_NAMESPACE_NAME }}/service_account/test-app-summon-sidecar
       annotations:
         kubernetes/authentication-container-name: authenticator
-        kubernetes: "true"
+        kubernetes: "{{ IS_KUBERNETES }}"
+    - !host
+      id: {{ TEST_APP_NAMESPACE_NAME }}/deployment/test-app-summon-sidecar
+      annotations:
+        kubernetes/authentication-container-name: authenticator
+        kubernetes: "{{ IS_KUBERNETES }}"
     - !host
       id: {{ TEST_APP_NAMESPACE_NAME }}/service_account/test-app-summon-init
       annotations:
         kubernetes/authentication-container-name: authenticator
-        kubernetes: "true"
+        kubernetes: "{{ IS_KUBERNETES }}"
+    - !host
+      id: {{ TEST_APP_NAMESPACE_NAME }}/deployment/test-app-summon-init
+      annotations:
+        kubernetes/authentication-container-name: authenticator
+        kubernetes: "{{ IS_KUBERNETES }}"
     - !host
       id: {{ TEST_APP_NAMESPACE_NAME }}/service_account/test-app-secretless
       annotations:
         kubernetes/authentication-container-name: secretless
-        kubernetes: "true"
+        kubernetes: "{{ IS_KUBERNETES }}"
+    - !host
+      id: {{ TEST_APP_NAMESPACE_NAME }}/deployment/test-app-secretless
+      annotations:
+        kubernetes/authentication-container-name: secretless
+        kubernetes: "{{ IS_KUBERNETES }}"
 
     - !host
       id: {{ TEST_APP_NAMESPACE_NAME }}/service_account/oc-test-app-summon-sidecar
       annotations:
         kubernetes/authentication-container-name: authenticator
-        openshift: "true"
+        openshift: "{{ IS_OPENSHIFT }}"
+    - !host
+      id: {{ TEST_APP_NAMESPACE_NAME }}/deployment/oc-test-app-summon-sidecar
+      annotations:
+        kubernetes/authentication-container-name: authenticator
+        openshift: "{{ IS_OPENSHIFT }}"
     - !host
       id: {{ TEST_APP_NAMESPACE_NAME }}/service_account/oc-test-app-summon-init
       annotations:
         kubernetes/authentication-container-name: authenticator
-        openshift: "true"
+        openshift: "{{ IS_OPENSHIFT }}"
+    - !host
+      id: {{ TEST_APP_NAMESPACE_NAME }}/deployment/oc-test-app-summon-init
+      annotations:
+        kubernetes/authentication-container-name: authenticator
+        openshift: "{{ IS_OPENSHIFT }}"
     - !host
       id: {{ TEST_APP_NAMESPACE_NAME }}/service_account/oc-test-app-secretless
       annotations:
         kubernetes/authentication-container-name: secretless
-        openshift: "true"
+        openshift: "{{ IS_OPENSHIFT }}"
+    - !host
+      id: {{ TEST_APP_NAMESPACE_NAME }}/deployment/oc-test-app-secretless
+      annotations:
+        kubernetes/authentication-container-name: secretless
+        openshift: "{{ IS_OPENSHIFT }}"
 
   - !grant
     role: !layer

--- a/set_env_vars.sh
+++ b/set_env_vars.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 # Set the default values of environment variables used by the scripts
 PLATFORM="${PLATFORM:-kubernetes}"  # default to kubernetes if env var not set
+CONJUR_AUTHN_LOGIN_RESOURCE="${CONJUR_AUTHN_LOGIN_RESOURCE:-service_account}" # default to service_account
 
 MINIKUBE="${MINIKUBE:-false}"
 MINISHIFT="${MINISHIFT:-false}"

--- a/utils.sh
+++ b/utils.sh
@@ -195,3 +195,21 @@ function pods_ready() {
 
   $cli describe pod --selector "app=$app_label" | awk '/Ready/{if ($2 != "True") exit 1}'
 }
+
+function urlencode() {
+    # urlencode <string>
+
+    # Run as a subshell so that we can indiscriminately set LC_COLLATE
+    (
+      LC_COLLATE=C
+
+      local length="${#1}"
+      for (( i = 0; i < length; i++ )); do
+          local c="${1:i:1}"
+          case $c in
+              [a-zA-Z0-9.~_-]) printf "$c" ;;
+              *) printf '%%%02X' "'$c" ;;
+          esac
+      done
+    )
+}


### PR DESCRIPTION
This change includes the following:
- Adds URL encoding for the Kubernetes authentication ID so that forwarding
  works for values with slashes such as `openshift/dap-support-19`.
- Adds support for optionally using an application's deployment name (rather
  than service account name) when authenticating with Kubernetes. This is
  enabled by setting the following environment:
```
     export CONJUR_AUTHN_LOGIN_RESOURCE=deployment
```
  The default is to use service account name when authenticating with
  Kubernetes.
- Fixes settings for openshift vs. kubernetes operation in the
  policy template to reflect what is set for the PLATFORM environment
  variable. For example, if PLATORM is set to "kubernetes", then
  the policy templates will render with the following lines:
```
  `openshift: "false"`
  `kubernetes: "true"`
```

These changes were made in order to investigate
[dap-support #19](https://github.com/conjurinc/dap-support/issues/19)