### PR TITLE
WIP: CI test cases exist for using deployment name as k8s authn ID

### DIFF
--- a/1_create_test_app_namespace.sh
+++ b/1_create_test_app_namespace.sh
@@ -39,6 +39,15 @@ if [[ $PLATFORM == openshift ]]; then
 
   oc adm policy add-role-to-user admin $OSHIFT_CONJUR_ADMIN_USERNAME -n default
   oc adm policy add-role-to-user admin $OSHIFT_CONJUR_ADMIN_USERNAME -n $TEST_APP_NAMESPACE_NAME
+  #oc adm policy add-role-to-user \
+  #    conjur-authenticator-$CONJUR_NAMESPACE_NAME \
+  #    system:serviceaccount:$CONJUR_NAMESPACE_NAME:conjur-cluster \
+  #    --rolebinding-name=test-app-conjur-authenticator-role-binding-$CONJUR_NAMESPACE_NAME \
+  #    -n $TEST_APP_NAMESPACE_NAME
+  #oc adm policy add-role-to-user \
+  #    conjur-authenticator-$CONJUR_NAMESPACE_NAME \
+  #    system:serviceaccount:$CONJUR_NAMESPACE_NAME:conjur-cluster \
+  #    --rolebinding-name=test-app-conjur-authenticator-role-binding-$CONJUR_NAMESPACE_NAME
   echo "Logging in as Conjur Openshift admin. Provide password as needed."
   oc login -u $OSHIFT_CONJUR_ADMIN_USERNAME
 fi

--- a/4_store_conjur_cert.sh
+++ b/4_store_conjur_cert.sh
@@ -11,6 +11,10 @@ echo "Retrieving Conjur certificate."
 
 if $cli get pods --selector role=follower --no-headers; then
   follower_pod_name=$($cli get pods --selector role=follower --no-headers | awk '{ print $1 }' | head -1)
+  $cli exec $follower_pod_name -- sed -i "s/:info/:debug/" /opt/conjur/possum/config/environments/appliance.rb
+  $cli exec $follower_pod_name -- sv restart conjur/possum
+  echo "****TEMP**** Sleep for 20 seconds to allow for possum restart"
+  sleep 20
   ssl_cert=$($cli exec $follower_pod_name -- cat /opt/conjur/etc/ssl/conjur.pem)
 else
   echo "Regular follower not found. Trying to assume a decomposed follower..."

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,60 +16,78 @@ pipeline {
     // Postgres Tests
     stage('Deploy Demos Postgres') {
       parallel {
-        stage('GKE, v5 Conjur, Postgres') {
+        //stage('GKE, v5 Conjur, Postgres') {
+        //  steps {
+        //    sh 'cd ci && summon --environment gke ./test gke postgres'
+        //  }
+        //}
+
+        //stage('GKE, v5 Conjur, Postgres, Deployment Authn ID') {
+        //  steps {
+        //    sh 'cd ci && CONJUR_AUTHN_LOGIN_RESOURCE=deployment summon --environment gke ./test gke postgres'
+        //  }
+        //}
+
+        //stage('OpenShift v3.9, v5 Conjur, Postgres') {
+        //  steps {
+        //    sh 'cd ci && summon --environment oc ./test oc postgres'
+        //  }
+        //}
+
+        stage('OpenShift v3.9, v5 Conjur, Postgres, Deployment Authn ID') {
           steps {
-            sh 'cd ci && summon --environment gke ./test gke postgres'
+            sh 'cd ci && CONJUR_AUTHN_LOGIN_RESOURCE=deployment_config summon --environment oc ./test oc postgres'
           }
         }
 
-        stage('OpenShift v3.9, v5 Conjur, Postgres') {
-          steps {
-            sh 'cd ci && summon --environment oc ./test oc postgres'
-          }
-        }
+        //stage('OpenShift v3.10, v5 Conjur, Postgres') {
+        //  steps {
+        //    sh 'cd ci && summon --environment oc310 ./test oc postgres'
+        //  }
+        //}
 
-        stage('OpenShift v3.10, v5 Conjur, Postgres') {
-          steps {
-            sh 'cd ci && summon --environment oc310 ./test oc postgres'
-          }
-        }
+        //stage('OpenShift v3.11, v5 Conjur, Postgres') {
+        //  steps {
+        //    sh 'cd ci && summon --environment oc311 ./test oc postgres'
+        //  }
+        //}
 
-        stage('OpenShift v3.11, v5 Conjur, Postgres') {
+        stage('OpenShift v3.11, v5 Conjur, Postgres, Deployment Authn ID') {
           steps {
-            sh 'cd ci && summon --environment oc311 ./test oc postgres'
+            sh 'cd ci && CONJUR_AUTHN_LOGIN_RESOURCE=deployment_config summon --environment oc311 ./test oc postgres'
           }
         }
       }
     }
 
 // MySQL Tests
-    stage('Deploy Demos MySQL') {
-      parallel {
-        stage('GKE, v5 Conjur, MySQL') {
-          steps {
-            sh 'cd ci && summon --environment gke ./test gke mysql'
-          }
-        }
-
-        stage('OpenShift v3.9, v5 Conjur, MySQL') {
-          steps {
-            sh 'cd ci && summon --environment oc ./test oc mysql'
-          }
-        }
-
-        stage('OpenShift v3.10, v5 Conjur, MySQL') {
-          steps {
-            sh 'cd ci && summon --environment oc310 ./test oc mysql'
-          }
-        }
-
-        stage('OpenShift v3.11, v5 Conjur, MySQL') {
-          steps {
-            sh 'cd ci && summon --environment oc311 ./test oc mysql'
-          }
-        }
-      }
-    }
+//    stage('Deploy Demos MySQL') {
+//      parallel {
+//        stage('GKE, v5 Conjur, MySQL') {
+//          steps {
+//            sh 'cd ci && summon --environment gke ./test gke mysql'
+//          }
+//        }
+//
+//        stage('OpenShift v3.9, v5 Conjur, MySQL') {
+//          steps {
+//            sh 'cd ci && summon --environment oc ./test oc mysql'
+//          }
+//        }
+//
+//        stage('OpenShift v3.10, v5 Conjur, MySQL') {
+//          steps {
+//            sh 'cd ci && summon --environment oc310 ./test oc mysql'
+//          }
+//        }
+//
+//        stage('OpenShift v3.11, v5 Conjur, MySQL') {
+//          steps {
+//            sh 'cd ci && summon --environment oc311 ./test oc mysql'
+//          }
+//        }
+//      }
+//    }
   }
 
   post {

--- a/ci/test
+++ b/ci/test
@@ -68,10 +68,11 @@ function main() {
 
 function deployConjur() {
   pushd ..
-    git clone --single-branch --branch master git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
+    #git clone --single-branch --branch master git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
+    git clone --single-branch --branch openshift_deploy_configs git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
   popd
 
-  runDockerCommand "cd kubernetes-conjur-deploy-$UNIQUE_TEST_ID && ./start"
+  runDockerCommand "cd kubernetes-conjur-deploy-$UNIQUE_TEST_ID && CONJUR_LOG_LEVEL=debug ./start"
 }
 
 function deployDemo() {
@@ -99,6 +100,8 @@ function prepareTestEnvironment() {
   export CONJUR_DEMO_TEST_IMAGE=conjur-demo-5-$UNIQUE_TEST_ID
 
   export CONJUR_APPLIANCE_IMAGE=$registry:5.0-stable
+
+  export CONJUR_AUTHN_LOGIN_RESOURCE="${CONJUR_AUTHN_LOGIN_RESOURCE:-service_account}"
 
   # Prepare Docker images
   docker pull $CONJUR_APPLIANCE_IMAGE
@@ -136,6 +139,7 @@ function runDockerCommand() {
     -e CONJUR_NAMESPACE_NAME \
     -e CONJUR_ACCOUNT \
     -e CONJUR_ADMIN_PASSWORD \
+    -e CONJUR_AUTHN_LOGIN_RESOURCE \
     -e AUTHENTICATOR_ID \
     -e TEST_APP_NAMESPACE_NAME \
     -e TEST_APP_DATABASE \

--- a/openshift/test-app-conjur-authenticator-role-binding.yml
+++ b/openshift/test-app-conjur-authenticator-role-binding.yml
@@ -8,6 +8,9 @@ subjects:
   - kind: ServiceAccount
     name: conjur-cluster
     namespace: {{ CONJUR_NAMESPACE_NAME }}
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: system:serviceaccount:{{ CONJUR_NAMESPACE_NAME }}:conjur-cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/openshift/test-app-secretless.yml
+++ b/openshift/test-app-secretless.yml
@@ -24,7 +24,7 @@ kind: DeploymentConfig
 metadata:
   labels:
     app: test-app-secretless
-  name: test-app-secretless
+  name: oc-test-app-secretless
 spec:
   replicas: 1
   selector:

--- a/openshift/test-app-summon-init.yml
+++ b/openshift/test-app-summon-init.yml
@@ -24,7 +24,7 @@ kind: DeploymentConfig
 metadata:
   labels:
     app: test-app-summon-init
-  name: test-app-summon-init
+  name: oc-test-app-summon-init
 spec:
   replicas: 1
   selector:

--- a/openshift/test-app-summon-sidecar.yml
+++ b/openshift/test-app-summon-sidecar.yml
@@ -24,7 +24,7 @@ kind: DeploymentConfig
 metadata:
   labels:
     app: test-app-summon-sidecar
-  name: test-app-summon-sidecar
+  name: oc-test-app-summon-sidecar
 spec:
   replicas: 1
   selector:

--- a/openshift/test-app-with-host-outside-apps-branch-summon-init.yml
+++ b/openshift/test-app-with-host-outside-apps-branch-summon-init.yml
@@ -24,7 +24,7 @@ kind: DeploymentConfig
 metadata:
   labels:
     app: test-app-with-host-outside-apps-branch-summon-init
-  name: test-app-with-host-outside-apps-branch-summon-init
+  name: oc-test-app-with-host-outside-apps-branch-summon-init
 spec:
   replicas: 1
   selector:

--- a/policy/templates/project-authn-def.template.yml
+++ b/policy/templates/project-authn-def.template.yml
@@ -53,7 +53,7 @@
         kubernetes/authentication-container-name: authenticator
         openshift: "{{ IS_OPENSHIFT }}"
     - !host
-      id: {{ TEST_APP_NAMESPACE_NAME }}/deployment/oc-test-app-summon-sidecar
+      id: {{ TEST_APP_NAMESPACE_NAME }}/deployment_config/oc-test-app-summon-sidecar
       annotations:
         kubernetes/authentication-container-name: authenticator
         openshift: "{{ IS_OPENSHIFT }}"
@@ -63,7 +63,7 @@
         kubernetes/authentication-container-name: authenticator
         openshift: "{{ IS_OPENSHIFT }}"
     - !host
-      id: {{ TEST_APP_NAMESPACE_NAME }}/deployment/oc-test-app-summon-init
+      id: {{ TEST_APP_NAMESPACE_NAME }}/deployment_config/oc-test-app-summon-init
       annotations:
         kubernetes/authentication-container-name: authenticator
         openshift: "{{ IS_OPENSHIFT }}"
@@ -73,7 +73,7 @@
         kubernetes/authentication-container-name: secretless
         openshift: "{{ IS_OPENSHIFT }}"
     - !host
-      id: {{ TEST_APP_NAMESPACE_NAME }}/deployment/oc-test-app-secretless
+      id: {{ TEST_APP_NAMESPACE_NAME }}/deployment_config/oc-test-app-secretless
       annotations:
         kubernetes/authentication-container-name: secretless
         openshift: "{{ IS_OPENSHIFT }}"


### PR DESCRIPTION
WIP: Adds CI test cases that use the Kubernetes authentication plugin
in both GKE and OpenShift environments, using Deployment name
(rather than the default service account name) as a Kubernetes
authentication ID.