### PR TITLE
Change image name to new name

### DIFF
--- a/6_deploy_test_app.sh
+++ b/6_deploy_test_app.sh
@@ -61,7 +61,7 @@ init_connection_specs() {
     authenticator_client_image=$(platform_image conjur-authn-k8s-client)
     secretless_image=$(platform_image secretless-broker)
   else
-    authenticator_client_image="cyberark/conjur-kubernetes-authenticator"
+    authenticator_client_image="cyberark/conjur-authn-k8s-client"
     secretless_image="cyberark/secretless-broker"
   fi
 


### PR DESCRIPTION
The image `cyberark/conjur-kubernetes-authenticator` will be deprecated in the future.
We should use the new name `conjur-authn-k8s-client` in our tests.