### PR TITLE
Remove redundant CONJUR_VERSION parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ This repo demonstrates an app retrieving secrets from a Conjur cluster running
 in Kubernetes or OpenShift. The numbered scripts perform the same steps that a
 user has to go through when setting up their own applications.
 
-**Note:** These demo scripts have only been tested with Dynamic Access Provider v10+. Older versions of Conjur Enterprise v4 and Conjur OSS are not supported.
+**Note:** These demo scripts have only been tested with the following products:
+  - Dynamic Access Provider v10+. Older versions of Conjur Enterprise v4 and Conjur OSS are not supported.
+  - cyberark/conjur-authn-k8s-client v0.11+
+  - cyberark/secretless-broker v1.0+
 
 # Setup
 

--- a/ci/test
+++ b/ci/test
@@ -90,8 +90,6 @@ function prepareTestEnvironment() {
   export AUTHENTICATOR_ID=conjur-5-$UNIQUE_TEST_ID-test
   export TEST_APP_NAMESPACE_NAME=test-app-5-$UNIQUE_TEST_ID
 
-  export CONJUR_VERSION=5 # still required by kubernetes-conjur-deploy
-
   export DEPLOY_MASTER_CLUSTER=true
 
   export MINI_ENV=false
@@ -131,7 +129,6 @@ function deleteRegistryImage() {
 function runDockerCommand() {
   docker run --rm \
     -i \
-    -e CONJUR_VERSION \
     -e CONJUR_APPLIANCE_IMAGE \
     -e CONJUR_NAMESPACE_NAME \
     -e CONJUR_ACCOUNT \

--- a/kubernetes/test-app-secretless.yml
+++ b/kubernetes/test-app-secretless.yml
@@ -58,8 +58,6 @@ spec:
         ports:
         - containerPort: 5432
         env:
-          - name: CONJUR_VERSION
-            value: "5"
           - name: MY_POD_NAME
             valueFrom:
               fieldRef:

--- a/kubernetes/test-app-summon-init.yml
+++ b/kubernetes/test-app-summon-init.yml
@@ -49,8 +49,6 @@ spec:
           initialDelaySeconds: 15
           timeoutSeconds: 5
         env:
-          - name: CONJUR_VERSION
-            value: "5"
           - name: CONJUR_APPLIANCE_URL
             value: "{{ CONJUR_APPLIANCE_URL }}"
           - name: CONJUR_ACCOUNT

--- a/kubernetes/test-app-summon-sidecar.yml
+++ b/kubernetes/test-app-summon-sidecar.yml
@@ -49,8 +49,6 @@ spec:
           initialDelaySeconds: 15
           timeoutSeconds: 5
         env:
-          - name: CONJUR_VERSION
-            value: "5"
           - name: CONJUR_APPLIANCE_URL
             value: "{{ CONJUR_APPLIANCE_URL }}"
           - name: CONJUR_ACCOUNT

--- a/kubernetes/test-app-with-host-outside-apps-branch-summon-init.yml
+++ b/kubernetes/test-app-with-host-outside-apps-branch-summon-init.yml
@@ -50,8 +50,6 @@ spec:
           initialDelaySeconds: 15
           timeoutSeconds: 5
         env:
-          - name: CONJUR_VERSION
-            value: "5"
           - name: CONJUR_APPLIANCE_URL
             value: "{{ CONJUR_APPLIANCE_URL }}"
           - name: CONJUR_ACCOUNT

--- a/openshift/test-app-secretless.yml
+++ b/openshift/test-app-secretless.yml
@@ -58,8 +58,6 @@ spec:
         ports:
         - containerPort: 5432
         env:
-          - name: CONJUR_VERSION
-            value: "5"
           - name: MY_POD_NAME
             valueFrom:
               fieldRef:

--- a/openshift/test-app-summon-init.yml
+++ b/openshift/test-app-summon-init.yml
@@ -49,8 +49,6 @@ spec:
           initialDelaySeconds: 15
           timeoutSeconds: 5
         env:
-          - name: CONJUR_VERSION
-            value: "5"
           - name: CONJUR_APPLIANCE_URL
             value: "{{ CONJUR_APPLIANCE_URL }}"
           - name: CONJUR_ACCOUNT

--- a/openshift/test-app-summon-sidecar.yml
+++ b/openshift/test-app-summon-sidecar.yml
@@ -49,8 +49,6 @@ spec:
           initialDelaySeconds: 15
           timeoutSeconds: 5
         env:
-          - name: CONJUR_VERSION
-            value: "5"
           - name: CONJUR_APPLIANCE_URL
             value: "{{ CONJUR_APPLIANCE_URL }}"
           - name: CONJUR_ACCOUNT

--- a/openshift/test-app-with-host-outside-apps-branch-summon-init.yml
+++ b/openshift/test-app-with-host-outside-apps-branch-summon-init.yml
@@ -49,8 +49,6 @@ spec:
           initialDelaySeconds: 15
           timeoutSeconds: 5
         env:
-          - name: CONJUR_VERSION
-            value: "5"
           - name: CONJUR_APPLIANCE_URL
             value: "{{ CONJUR_APPLIANCE_URL }}"
           - name: CONJUR_ACCOUNT


### PR DESCRIPTION
The parameter `CONJUR_VERSION` is not required anymore in the
`conjur-authn-k8s-client` and is defaulted to `5`. We should remove
them from this project too when we deploy pods of the `conjur-authn-k8s-client`
and the `secretless-broker` to verify that it is indeed not required.