### PR TITLE
Remove CONJUR_APPLIANCE_URL from authenticator image

### DIFF
--- a/kubernetes/test-app-with-host-outside-apps-branch-summon-init.yml
+++ b/kubernetes/test-app-with-host-outside-apps-branch-summon-init.yml
@@ -84,8 +84,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: CONJUR_APPLIANCE_URL
-            value: "{{ CONJUR_APPLIANCE_URL }}"
           - name: CONJUR_AUTHN_URL
             value: "{{ CONJUR_AUTHN_URL }}"
           - name: CONJUR_ACCOUNT

--- a/openshift/test-app-summon-init.yml
+++ b/openshift/test-app-summon-init.yml
@@ -83,8 +83,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: CONJUR_APPLIANCE_URL
-            value: "{{ CONJUR_APPLIANCE_URL }}"
           - name: CONJUR_AUTHN_URL
             value: "{{ CONJUR_AUTHN_URL }}"
           - name: CONJUR_ACCOUNT

--- a/openshift/test-app-summon-sidecar.yml
+++ b/openshift/test-app-summon-sidecar.yml
@@ -80,8 +80,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: CONJUR_APPLIANCE_URL
-            value: "{{ CONJUR_APPLIANCE_URL }}"
           - name: CONJUR_AUTHN_URL
             value: "{{ CONJUR_AUTHN_URL }}"
           - name: CONJUR_ACCOUNT

--- a/openshift/test-app-with-host-outside-apps-branch-summon-init.yml
+++ b/openshift/test-app-with-host-outside-apps-branch-summon-init.yml
@@ -83,8 +83,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: CONJUR_APPLIANCE_URL
-            value: "{{ CONJUR_APPLIANCE_URL }}"
           - name: CONJUR_AUTHN_URL
             value: "{{ CONJUR_AUTHN_URL }}"
           - name: CONJUR_ACCOUNT


### PR DESCRIPTION
The authn-k8s client image does not require the appliance URL to be able to
authenticate with Conjur. In this commit, we remove the appliance URLs from the
Authenticator containers.

Note that the _app_ container will still need the appliance URL to authenticate
with Conjur via the default authenticator, once the access token is available
to the application.

Secretless also still needs the appliance URL, since it instantiates the Go
client using the access token it retrieves via Kubernetes authentication.