### PR TITLE
Pass CONJUR_LOG_LEVEL env var to docker container

### DIFF
--- a/ci/test
+++ b/ci/test
@@ -150,6 +150,7 @@ function runDockerCommand() {
     -e OPENSHIFT_PASSWORD \
     -e OSHIFT_CONJUR_ADMIN_USERNAME \
     -e OSHIFT_CLUSTER_ADMIN_USERNAME \
+    -e CONJUR_LOG_LEVEL \
     -v $GCLOUD_SERVICE_KEY:/tmp$GCLOUD_SERVICE_KEY \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v ~/.config:/root/.config \


### PR DESCRIPTION
We have the ability to set CONJUR_LOG_LEVEL in the env so
when we deploy Conjur it will also set the log level of the
DAP cluster to the given level. TO enable this feature in this project
we need to pass the variable in the Docker command to the container
that will run the Conjur deployment