### PR TITLE
Set and pass TEST_PLATFORM env var to docker container

### DIFF
--- a/ci/secrets.yml
+++ b/ci/secrets.yml
@@ -16,6 +16,7 @@ gke:
   OPENSHIFT_PASSWORD: ""
 
   PLATFORM: kubernetes
+  TEST_PLATFORM: gke
   DOCKER_REGISTRY_URL: us.gcr.io
   DOCKER_REGISTRY_PATH: us.gcr.io/conjur-gke-dev
 
@@ -32,6 +33,7 @@ oc:
   OSHIFT_CONJUR_ADMIN_USERNAME: !var ci/openshift/3.9/username
 
   PLATFORM: openshift
+  TEST_PLATFORM: openshift39
   DOCKER_REGISTRY_URL: !var ci/openshift/3.9/registry-url
   DOCKER_REGISTRY_PATH: !var ci/openshift/3.9/registry-url
 
@@ -48,6 +50,7 @@ oc310:
   OSHIFT_CONJUR_ADMIN_USERNAME: !var ci/openshift/3.10/username
 
   PLATFORM: openshift
+  TEST_PLATFORM: openshift310
   DOCKER_REGISTRY_URL: !var ci/openshift/3.10/registry-url
   DOCKER_REGISTRY_PATH: !var ci/openshift/3.10/registry-url
 
@@ -64,5 +67,6 @@ oc311:
   OSHIFT_CONJUR_ADMIN_USERNAME: !var ci/openshift/3.11/username
 
   PLATFORM: openshift
+  TEST_PLATFORM: openshift311
   DOCKER_REGISTRY_URL: !var ci/openshift/3.11/registry-url
   DOCKER_REGISTRY_PATH: !var ci/openshift/3.11/registry-url

--- a/ci/test
+++ b/ci/test
@@ -137,6 +137,7 @@ function runDockerCommand() {
     -e TEST_APP_NAMESPACE_NAME \
     -e TEST_APP_DATABASE \
     -e PLATFORM \
+    -e TEST_PLATFORM \
     -e DOCKER_REGISTRY_URL \
     -e DOCKER_REGISTRY_PATH \
     -e MINI_ENV \


### PR DESCRIPTION
[This PR](https://github.com/cyberark/kubernetes-conjur-deploy/pull/137) added the use
of the TEST_PLATFORM env var in the `./start.sh` script that is used in this repo.

This means that we need to set and pass this variable when running the script. Please see [this comment](https://github.com/cyberark/kubernetes-conjur-deploy/pull/137#discussion_r484049147) on the other PR that stated why this 
PR is needed and why this is not the optimal solution.