### PR TITLE
Adds CI for testing annotation-based authn on OpenShift with DAP

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,13 +45,29 @@ pipeline {
     // Postgres Tests with Annotation-based Authn
     stage('Deploy Demos Postgres with Annotation-based Authn') {
       parallel {
-        stage('GKE, v5 Conjur, Postgres, Annotation--based Authn') {
+        stage('GKE, v5 Conjur, Postgres, Annotation-based Authn') {
           steps {
             sh 'cd ci && summon --environment gke ./test gke postgres annotation-based'
           }
         }
 
-        // TODO: Add OpenShift Annotation-based authentication tests
+        stage('OpenShift v3.9, v5 Conjur, Postgres, Annotation-based Authn') {
+          steps {
+            sh 'cd ci && summon --environment oc ./test oc postgres annotation-based'
+          }
+        }
+
+        stage('OpenShift v3.10, v5 Conjur, Postgres, Annotation-based Authn') {
+          steps {
+            sh 'cd ci && summon --environment oc310 ./test oc postgres annotation-based'
+          }
+        }
+
+        stage('OpenShift v3.11, v5 Conjur, Postgres, Annotation-based Authn') {
+          steps {
+            sh 'cd ci && summon --environment oc311 ./test oc postgres annotation-based'
+          }
+        }
       }
     }
 

--- a/policy/templates/project-authn-def.template.yml
+++ b/policy/templates/project-authn-def.template.yml
@@ -42,7 +42,6 @@
       annotations:
         authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
         authn-k8s/service-account: oc-test-app-summon-sidecar
-        authn-k8s/deployment-config: test-app-summon-sidecar
         authn-k8s/authentication-container-name: authenticator
         openshift: "{{ IS_OPENSHIFT }}"
     - !host
@@ -50,7 +49,6 @@
       annotations:
         authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
         authn-k8s/service-account: oc-test-app-summon-init
-        authn-k8s/deployment-config: test-app-summon-init
         authn-k8s/authentication-container-name: authenticator
         openshift: "{{ IS_OPENSHIFT }}"
     - !host
@@ -58,7 +56,6 @@
       annotations:
         authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
         authn-k8s/service-account: oc-test-app-secretless
-        authn-k8s/deployment-config: test-app-secretless
         authn-k8s/authentication-container-name: secretless
         openshift: "{{ IS_OPENSHIFT }}"
 


### PR DESCRIPTION
# Adds CI for testing annotation-based authn on OpenShift with DAP

The current CI test cases test authn-k8s on OpenShift platforms using host-ID-based
authentication. This change adds test cases for testing authn-k8s on OpenShift using
DAP and the newer-style, annotation-based authentication, where the Kubernetes
resources being authenticated are configured as annotations on the host definition
in the Conjur policy.

NOTE: The annotation-based tests that are being added do not include the use of
the OpenShift `DeploymentConfigs` resources as application identity. This will be
addressed with the following:

- https://github.com/cyberark/kubernetes-conjur-deploy/pull/158
- https://github.com/conjurdemos/kubernetes-conjur-demo/issues/115
- https://github.com/conjurdemos/kubernetes-conjur-demo/pull/112

Addresses Issue #109 