### PR TITLE
WIP: Add CI to test authn-k8s using OpenShift DeploymentConfigs

### DIFF
--- a/8_app_verify_authentication.sh
+++ b/8_app_verify_authentication.sh
@@ -24,6 +24,7 @@ function finish {
   if [[ "$DETAILED_DUMP_ON_EXIT" == "true" ]]; then
     dump_kubernetes_resources
     dump_authentication_policy
+    dump_conjur_logs
   fi
 
   set +u

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,54 +14,54 @@ pipeline {
 
   stages {
     // Postgres Tests with Host-ID-based Authn
-    stage('Deploy Demos Postgres with Host-ID-based Authn') {
-      parallel {
-        stage('GKE, v5 Conjur, Postgres, Host-ID-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment gke ./test gke postgres host-id-based'
-          }
-        }
+    //stage('Deploy Demos Postgres with Host-ID-based Authn') {
+    //  parallel {
+    //    stage('GKE, v5 Conjur, Postgres, Host-ID-based Authn') {
+    //      steps {
+    //        sh 'cd ci && summon --environment gke ./test gke postgres host-id-based'
+    //      }
+    //    }
 
-        stage('OpenShift v3.9, v5 Conjur, Postgres, Host-ID-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment oc ./test oc postgres host-id-based'
-          }
-        }
+    //    stage('OpenShift v3.9, v5 Conjur, Postgres, Host-ID-based Authn') {
+    //      steps {
+    //        sh 'cd ci && summon --environment oc ./test oc postgres host-id-based'
+    //      }
+    //    }
 
-        stage('OpenShift v3.10, v5 Conjur, Postgres, Host-ID-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment oc310 ./test oc postgres host-id-based'
-          }
-        }
+    //    stage('OpenShift v3.10, v5 Conjur, Postgres, Host-ID-based Authn') {
+    //      steps {
+    //        sh 'cd ci && summon --environment oc310 ./test oc postgres host-id-based'
+    //      }
+    //    }
 
-        stage('OpenShift v3.11, v5 Conjur, Postgres, Host-ID-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment oc311 ./test oc postgres host-id-based'
-          }
-        }
-      }
-    }
+    //    stage('OpenShift v3.11, v5 Conjur, Postgres, Host-ID-based Authn') {
+    //      steps {
+    //        sh 'cd ci && summon --environment oc311 ./test oc postgres host-id-based'
+    //      }
+    //    }
+    //  }
+    //}
 
     // Postgres Tests with Annotation-based Authn
     stage('Deploy Demos Postgres with Annotation-based Authn') {
       parallel {
-        stage('GKE, v5 Conjur, Postgres, Annotation-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment gke ./test gke postgres annotation-based'
-          }
-        }
+        //stage('GKE, v5 Conjur, Postgres, Annotation-based Authn') {
+        //  steps {
+        //    sh 'cd ci && summon --environment gke ./test gke postgres annotation-based'
+        //  }
+        //}
 
-        stage('OpenShift v3.9, v5 Conjur, Postgres, Annotation-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment oc ./test oc postgres annotation-based'
-          }
-        }
+        //stage('OpenShift v3.9, v5 Conjur, Postgres, Annotation-based Authn') {
+        //  steps {
+        //    sh 'cd ci && summon --environment oc ./test oc postgres annotation-based'
+        //  }
+        //}
 
-        stage('OpenShift v3.10, v5 Conjur, Postgres, Annotation-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment oc310 ./test oc postgres annotation-based'
-          }
-        }
+        //stage('OpenShift v3.10, v5 Conjur, Postgres, Annotation-based Authn') {
+        //  steps {
+        //    sh 'cd ci && summon --environment oc310 ./test oc postgres annotation-based'
+        //  }
+        //}
 
         stage('OpenShift v3.11, v5 Conjur, Postgres, Annotation-based Authn') {
           steps {
@@ -72,34 +72,34 @@ pipeline {
     }
 
     // MySQL Tests
-    stage('Deploy Demos MySQL') {
-      parallel {
-        stage('GKE, v5 Conjur, MySQL, Host-ID-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment gke ./test gke mysql host-id-based'
-          }
-        }
+    //stage('Deploy Demos MySQL') {
+    //  parallel {
+    //    stage('GKE, v5 Conjur, MySQL, Host-ID-based Authn') {
+    //      steps {
+    //        sh 'cd ci && summon --environment gke ./test gke mysql host-id-based'
+    //      }
+    //    }
 
-        stage('OpenShift v3.9, v5 Conjur, MySQL, Host-ID-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment oc ./test oc mysql host-id-based'
-          }
-        }
+    //    stage('OpenShift v3.9, v5 Conjur, MySQL, Host-ID-based Authn') {
+    //      steps {
+    //        sh 'cd ci && summon --environment oc ./test oc mysql host-id-based'
+    //      }
+    //    }
 
-        stage('OpenShift v3.10, v5 Conjur, MySQL, Host-ID-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment oc310 ./test oc mysql host-id-based'
-          }
-        }
+    //    stage('OpenShift v3.10, v5 Conjur, MySQL, Host-ID-based Authn') {
+    //      steps {
+    //        sh 'cd ci && summon --environment oc310 ./test oc mysql host-id-based'
+    //      }
+    //    }
 
-        stage('OpenShift v3.11, v5 Conjur, MySQL, Host-ID-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment oc311 ./test oc mysql host-id-based'
-          }
-        }
+    //    stage('OpenShift v3.11, v5 Conjur, MySQL, Host-ID-based Authn') {
+    //      steps {
+    //        sh 'cd ci && summon --environment oc311 ./test oc mysql host-id-based'
+    //      }
+    //    }
 
-      }
-    }
+    //  }
+    //}
   }
 
   post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,13 +45,29 @@ pipeline {
     // Postgres Tests with Annotation-based Authn
     stage('Deploy Demos Postgres with Annotation-based Authn') {
       parallel {
-        stage('GKE, v5 Conjur, Postgres, Annotation--based Authn') {
+        stage('GKE, v5 Conjur, Postgres, Annotation-based Authn') {
           steps {
             sh 'cd ci && summon --environment gke ./test gke postgres annotation-based'
           }
         }
 
-        // TODO: Add OpenShift Annotation-based authentication tests
+        stage('OpenShift v3.9, v5 Conjur, Postgres, Annotation-based Authn') {
+          steps {
+            sh 'cd ci && summon --environment oc ./test oc postgres annotation-based'
+          }
+        }
+
+        stage('OpenShift v3.10, v5 Conjur, Postgres, Annotation-based Authn') {
+          steps {
+            sh 'cd ci && summon --environment oc310 ./test oc postgres annotation-based'
+          }
+        }
+
+        stage('OpenShift v3.11, v5 Conjur, Postgres, Annotation-based Authn') {
+          steps {
+            sh 'cd ci && summon --environment oc311 ./test oc postgres annotation-based'
+          }
+        }
       }
     }
 

--- a/ci/test
+++ b/ci/test
@@ -70,10 +70,11 @@ function main() {
 
 function deployConjur() {
   pushd ..
-    git clone --single-branch --branch master git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
+    #git clone --single-branch --branch master git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
+    git clone --single-branch --branch add_oc_deploy_configs git@github.com:cyberark/kubernetes-conjur-deploy kubernetes-conjur-deploy-$UNIQUE_TEST_ID
   popd
 
-  runDockerCommand "cd kubernetes-conjur-deploy-$UNIQUE_TEST_ID && ./start"
+  runDockerCommand "cd kubernetes-conjur-deploy-$UNIQUE_TEST_ID && CONJUR_LOG_LEVEL=debug ./start"
 }
 
 function deployDemo() {

--- a/policy/templates/project-authn-def.template.yml
+++ b/policy/templates/project-authn-def.template.yml
@@ -42,7 +42,6 @@
       annotations:
         authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
         authn-k8s/service-account: oc-test-app-summon-sidecar
-        authn-k8s/deployment-config: test-app-summon-sidecar
         authn-k8s/authentication-container-name: authenticator
         openshift: "{{ IS_OPENSHIFT }}"
     - !host
@@ -50,7 +49,6 @@
       annotations:
         authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
         authn-k8s/service-account: oc-test-app-summon-init
-        authn-k8s/deployment-config: test-app-summon-init
         authn-k8s/authentication-container-name: authenticator
         openshift: "{{ IS_OPENSHIFT }}"
     - !host
@@ -58,7 +56,6 @@
       annotations:
         authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
         authn-k8s/service-account: oc-test-app-secretless
-        authn-k8s/deployment-config: test-app-secretless
         authn-k8s/authentication-container-name: secretless
         openshift: "{{ IS_OPENSHIFT }}"
 

--- a/policy/templates/project-authn-def.template.yml
+++ b/policy/templates/project-authn-def.template.yml
@@ -42,6 +42,7 @@
       annotations:
         authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
         authn-k8s/service-account: oc-test-app-summon-sidecar
+        authn-k8s/deployment-config: test-app-summon-sidecar
         authn-k8s/authentication-container-name: authenticator
         openshift: "{{ IS_OPENSHIFT }}"
     - !host
@@ -49,6 +50,7 @@
       annotations:
         authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
         authn-k8s/service-account: oc-test-app-summon-init
+        authn-k8s/deployment-config: test-app-summon-init
         authn-k8s/authentication-container-name: authenticator
         openshift: "{{ IS_OPENSHIFT }}"
     - !host
@@ -56,6 +58,7 @@
       annotations:
         authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
         authn-k8s/service-account: oc-test-app-secretless
+        authn-k8s/deployment-config: test-app-secretless
         authn-k8s/authentication-container-name: secretless
         openshift: "{{ IS_OPENSHIFT }}"
 


### PR DESCRIPTION
WIP: This change adds a test for using DeploymentConfigs OpenShift resources
as application identity for Conjur authn-k8s authentication.

This change will allow the authn-k8s plugin to compare an application's DeploymentConfig
with DeploymentConfigs that are permitted (via annotatoins) in Conjur policy.

Addresses Issue #115 