### PR TITLE
Add OPENSHIFT_VERSION to test environments

### DIFF
--- a/ci/secrets.yml
+++ b/ci/secrets.yml
@@ -26,6 +26,7 @@ oc:
   GCLOUD_PROJECT_NAME: ""
   GCLOUD_SERVICE_KEY: ""
 
+  OPENSHIFT_VERSION: '3.9'
   OPENSHIFT_URL: !var ci/openshift/3.9/hostname
   OPENSHIFT_USERNAME: !var ci/openshift/3.9/username
   OPENSHIFT_PASSWORD: !var ci/openshift/3.9/password
@@ -43,6 +44,7 @@ oc310:
   GCLOUD_PROJECT_NAME: ""
   GCLOUD_SERVICE_KEY: ""
 
+  OPENSHIFT_VERSION: '3.10'
   OPENSHIFT_URL: !var ci/openshift/3.10/hostname
   OPENSHIFT_USERNAME: !var ci/openshift/3.10/username
   OPENSHIFT_PASSWORD: !var ci/openshift/3.10/password
@@ -60,6 +62,7 @@ oc311:
   GCLOUD_PROJECT_NAME: ""
   GCLOUD_SERVICE_KEY: ""
 
+  OPENSHIFT_VERSION: '3.11'
   OPENSHIFT_URL: !var ci/openshift/3.11/hostname
   OPENSHIFT_USERNAME: !var ci/openshift/3.11/username
   OPENSHIFT_PASSWORD: !var ci/openshift/3.11/password

--- a/ci/test
+++ b/ci/test
@@ -151,6 +151,7 @@ function runDockerCommand() {
     -e GCLOUD_CLUSTER_NAME \
     -e GCLOUD_ZONE \
     -e GCLOUD_PROJECT_NAME \
+    -e OPENSHIFT_VERSION \
     -e OPENSHIFT_URL \
     -e OPENSHIFT_USERNAME \
     -e OPENSHIFT_PASSWORD \


### PR DESCRIPTION
The kubernetes-conjur-deploy project now expects this environment variable to determine how it should deploy the Conjur or DAP server to test against. This allows it to account for changes from OC 3 to OC 4.

See: https://github.com/cyberark/kubernetes-conjur-deploy/pull/163

Connected to https://github.com/conjurinc/appliance/issues/1486