### PR TITLE
Eliminates hanging on namespace deletion for OpenShift 4.3

### DIFF
--- a/stop
+++ b/stop
@@ -3,17 +3,34 @@ set -euo pipefail
 
 . utils.sh
 
-set_namespace $TEST_APP_NAMESPACE_NAME
-$cli get pods
+KUBE_CLI_DELETE_TIMEOUT="10m"
+
+set_namespace "$TEST_APP_NAMESPACE_NAME"
+"$cli" get pods
 
 set_namespace default
 
-if [[ $PLATFORM == openshift ]]; then
-  oc login -u $OSHIFT_CLUSTER_ADMIN_USERNAME -p $OPENSHIFT_PASSWORD
+if [[ "$PLATFORM" == "openshift" ]]; then
+  oc login -u "$OSHIFT_CLUSTER_ADMIN_USERNAME" -p "$OPENSHIFT_PASSWORD"
 fi
 
-if has_namespace $TEST_APP_NAMESPACE_NAME; then
-  $cli delete namespace $TEST_APP_NAMESPACE_NAME
+if has_namespace "$TEST_APP_NAMESPACE_NAME"; then
+  if [[ "$OPENSHIFT_VERSION" == "4.3" ]]; then
+    # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1798282
+    for svc in `$cli get svc -n "$TEST_APP_NAMESPACE_NAME" -o name`; do
+      echo "Deleting finalizers from Kubernetes service $svc"
+      "$cli" patch "$svc" \
+          --namespace "$TEST_APP_NAMESPACE_NAME" \
+          --type=json \
+          --patch='[{"op":"replace","path":"/metadata/finalizers","value":[]}]'
+    done
+  fi
+
+  "$cli" delete --timeout="$KUBE_CLI_DELETE_TIMEOUT" \
+      namespace "$TEST_APP_NAMESPACE_NAME" || \
+      echo "ERROR: Delete of namespace $TEST_APP_NAMESPACE_NAME failed"
+      echo "Showing residual resources in namespace:"
+      "$cli" describe all -n "$TEST_APP_NAMESPACE_NAME"
 
   printf "Waiting for $TEST_APP_NAMESPACE_NAME namespace deletion to complete"
 

--- a/utils.sh
+++ b/utils.sh
@@ -70,7 +70,7 @@ platform_image_for_push() {
 }
 
 has_namespace() {
-  if $cli get namespace  "$1" > /dev/null; then
+  if $cli get namespace  "$1" &>/dev/null; then
     true
   else
     false


### PR DESCRIPTION
This change adds:

- A workaround for an OpenShift 4.3 bug (https://bugzilla.redhat.com/show_bug.cgi?id=1798282)
  whereby deleting a namespace may hang indefitely because sometimes finalizers are left undeleted
  on Kubernetes services in the namespace.
- A display of residual Kubernetes resources when namespace delete fails.

NOTE: Jenkins tests are currently failing on OpenShift 4.5. This failure is unrelated to the change
being made here. The failures for OpenShift 4.5 appear could possibly be due to improper
credentials being set for this routine in platform_login:

```
  elif [[ "$PLATFORM" = "openshift" ]]; then
    oc login $OPENSHIFT_URL \
      --username=$OPENSHIFT_USERNAME \
      --password=$OPENSHIFT_PASSWORD \
      --insecure-skip-tls-verify=true
    docker login \
      -u _ -p "$(oc whoami -t)" \
      $DOCKER_REGISTRY_PATH
  fi
```

Addresses Issue #125 