### PR TITLE
Adds check for platform before checking OPENSHIFT_VERSION

### DIFF
--- a/stop
+++ b/stop
@@ -15,7 +15,7 @@ if [[ "$PLATFORM" == "openshift" ]]; then
 fi
 
 if has_namespace "$TEST_APP_NAMESPACE_NAME"; then
-  if [[ "$OPENSHIFT_VERSION" == "4.3" ]]; then
+  if [[ "$PLATFORM" == "openshift" && "$OPENSHIFT_VERSION" == "4.3" ]]; then
     # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1798282
     for svc in `$cli get svc -n "$TEST_APP_NAMESPACE_NAME" -o name`; do
       echo "Deleting finalizers from Kubernetes service $svc"
@@ -28,8 +28,8 @@ if has_namespace "$TEST_APP_NAMESPACE_NAME"; then
 
   "$cli" delete --timeout="$KUBE_CLI_DELETE_TIMEOUT" \
       namespace "$TEST_APP_NAMESPACE_NAME" || \
-      echo "ERROR: Delete of namespace $TEST_APP_NAMESPACE_NAME failed"
-      echo "Showing residual resources in namespace:"
+      echo "ERROR: Delete of namespace $TEST_APP_NAMESPACE_NAME failed" && \
+      echo "Showing residual resources in namespace:" && \
       "$cli" describe all -n "$TEST_APP_NAMESPACE_NAME"
 
   printf "Waiting for $TEST_APP_NAMESPACE_NAME namespace deletion to complete"


### PR DESCRIPTION
In the stop script, there is a check for the value of the `$OPENSHIFT_VERSION`
without first checking that the `$PLATFORM` environment variable is set to
"openshift". This can result in a undefined variable error for
`$OPENSHIFT_VERSION`.

This change adds a check that `$PLATFORM` is set to "openshift" before
checking `$OPENSHIFT_VERSION` value.