### PR TITLE
Removes loadbalancers for OC 4.3 tests to eliminate hangs

### DIFF
--- a/ci/secrets.yml
+++ b/ci/secrets.yml
@@ -44,6 +44,8 @@ oc43:
   OPENSHIFT_PASSWORD: !var ci/openshift/oldest/password
   OSHIFT_CLUSTER_ADMIN_USERNAME: !var ci/openshift/oldest/username
   OSHIFT_CONJUR_ADMIN_USERNAME: !var ci/openshift/oldest/username
+  # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1798282
+  TEST_APP_LOADBALANCER_SVCS: false
 
   PLATFORM: openshift
   TEST_PLATFORM: openshift43

--- a/ci/test
+++ b/ci/test
@@ -160,6 +160,7 @@ function runDockerCommand() {
     -e OSHIFT_CONJUR_ADMIN_USERNAME \
     -e OSHIFT_CLUSTER_ADMIN_USERNAME \
     -e CONJUR_LOG_LEVEL \
+    -e TEST_APP_LOADBALANCER_SVCS \
     -v $GCLOUD_SERVICE_KEY:/tmp$GCLOUD_SERVICE_KEY \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v ~/.config:/root/.config \

--- a/stop
+++ b/stop
@@ -15,22 +15,11 @@ if [[ "$PLATFORM" == "openshift" ]]; then
 fi
 
 if has_namespace "$TEST_APP_NAMESPACE_NAME"; then
-  if [[ "$PLATFORM" == "openshift" && "$OPENSHIFT_VERSION" == "4.3" ]]; then
-    # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1798282
-    for svc in `$cli get svc -n "$TEST_APP_NAMESPACE_NAME" -o name`; do
-      echo "Deleting finalizers from Kubernetes service $svc"
-      "$cli" patch "$svc" \
-          --namespace "$TEST_APP_NAMESPACE_NAME" \
-          --type=json \
-          --patch='[{"op":"replace","path":"/metadata/finalizers","value":[]}]'
-    done
-  fi
-
   "$cli" delete --timeout="$KUBE_CLI_DELETE_TIMEOUT" \
       namespace "$TEST_APP_NAMESPACE_NAME" || \
-      echo "ERROR: Delete of namespace $TEST_APP_NAMESPACE_NAME failed" && \
+      (echo "ERROR: Delete of namespace $TEST_APP_NAMESPACE_NAME failed" && \
       echo "Showing residual resources in namespace:" && \
-      "$cli" describe all -n "$TEST_APP_NAMESPACE_NAME"
+      "$cli" describe all -n "$TEST_APP_NAMESPACE_NAME")
 
   printf "Waiting for $TEST_APP_NAMESPACE_NAME namespace deletion to complete"
 


### PR DESCRIPTION
OpenShift Version 4.3 has a known bug whereby deletion of services
that use LoadBalancers (or namespaces that contain such services)
can cause indefinite hanging. Apparently there are finalizers used
on these services to force cleanup of loadbalancer resources, and
the finalizers are never deleted from the service:
  https://bugzilla.redhat.com/show_bug.cgi?id=1798282

This change disables the use of LoadBalancers for the OpenShift 4.3
testing as a temporary workaround.

NOTE: There is a similar change required in the cyberark/kubernetes-conjur-deploy
since Conjur is being deployed with services that use LoadBalancers. The change
that we come up for cyberark/kubernetes-conjur-deploy will probably need
an environment variable setting in the CI builds in this demo repo for OC 4.3.
That work will be added separately.

Addresses Issue #125 