### PR TITLE
Remove hardcoded OCP versions and replace with oldest, current and next.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,13 @@ pipeline {
     cron(getDailyCronString())
   }
 
+  parameters { 
+    booleanParam(
+      name: 'TEST_OCP_NEXT',
+      description: 'Whether or not to run the pipeline against the next OCP version',
+      defaultValue: false) 
+  }
+
   stages {
     // Postgres Tests with Host-ID-based Authn
     stage('Deploy Demos Postgres with Host-ID-based Authn') {
@@ -28,15 +35,30 @@ pipeline {
           }
         }
 
-        stage('OpenShift v4.3, v5 Conjur, Postgres, Host-ID-based Authn') {
+        stage('OpenShift v(oldest), v5 Conjur, Postgres, Host-ID-based Authn') {
           steps {
-            sh 'cd ci && summon --environment oc43 ./test oc postgres host-id-based'
+            sh 'cd ci && summon --environment oldest ./test oc postgres host-id-based'
           }
         }
 
-        stage('OpenShift v4.5, v5 Conjur, Postgres, Host-ID-based Authn') {
+        stage('OpenShift v(current), v5 Conjur, Postgres, Host-ID-based Authn') {
           steps {
-            sh 'cd ci && summon --environment oc45 ./test oc postgres host-id-based'
+            sh 'cd ci && summon --environment current ./test oc postgres host-id-based'
+          }
+        }
+
+        stage('OpenShift v(next)') {
+          when { 
+            expression { params.TEST_OCP_NEXT } 
+          }
+
+          stages {
+
+            stage('OpenShift v(next), v5 Conjur, Postgres, Host-ID-based Authn') {
+              steps {
+                sh 'cd ci && summon --environment next ./test oc postgres host-id-based'
+              }
+            }
           }
         }
       }
@@ -45,7 +67,7 @@ pipeline {
     // Postgres Tests with Annotation-based Authn
     stage('Deploy Demos Postgres with Annotation-based Authn') {
       parallel {
-        stage('GKE, v5 Conjur, Postgres, Annotation-based Authn') {
+      stage('GKE, v5 Conjur, Postgres, Annotation-based Authn') {
           steps {
             sh 'cd ci && summon --environment gke ./test gke postgres annotation-based'
           }
@@ -57,15 +79,30 @@ pipeline {
           }
         }
 
-        stage('OpenShift v4.3, v5 Conjur, Postgres, Annotation-based Authn') {
+        stage('OpenShift v(oldest), v5 Conjur, Postgres, Annotation-based Authn') {
           steps {
-            sh 'cd ci && summon --environment oc43 ./test oc postgres annotation-based'
+            sh 'cd ci && summon --environment oldest ./test oc postgres annotation-based'
           }
         }
 
-        stage('OpenShift v4.5, v5 Conjur, Postgres, Annotation-based Authn') {
+        stage('OpenShift v(current), v5 Conjur, Postgres, Annotation-based Authn') {
           steps {
-            sh 'cd ci && summon --environment oc45 ./test oc postgres annotation-based'
+            sh 'cd ci && summon --environment current ./test oc postgres annotation-based'
+          }
+        }
+
+        stage('OpenShift v(next)') {
+          when {
+            expression { params.TEST_OCP_NEXT }
+          }
+
+          stages {
+
+            stage('OpenShift v(next), v5 Conjur, Postgres, Annotation-based Authn') {
+              steps {
+                sh 'cd ci && summon --environment next ./test oc postgres annotation-based'
+              }
+            }
           }
         }
       }
@@ -86,15 +123,28 @@ pipeline {
           }
         }
 
-        stage('OpenShift v4.3, v5 Conjur, MySQL, Host-ID-based Authn') {
+        stage('OpenShift v(oldest), v5 Conjur, MySQL, Host-ID-based Authn') {
           steps {
-            sh 'cd ci && summon --environment oc43 ./test oc mysql host-id-based'
+            sh 'cd ci && summon --environment oldest ./test oc mysql host-id-based'
           }
         }
 
-        stage('OpenShift v4.5, v5 Conjur, MySQL, Host-ID-based Authn') {
+        stage('OpenShift v(current), v5 Conjur, MySQL, Host-ID-based Authn') {
           steps {
-            sh 'cd ci && summon --environment oc45 ./test oc mysql host-id-based'
+            sh 'cd ci && summon --environment current ./test oc mysql host-id-based'
+          }
+        }
+        stage('OpenShift v(next)') {
+          when {
+            expression { params.TEST_OCP_NEXT }
+          }
+
+          stages {
+            stage('OpenShift v(next), v5 Conjur, MySQL, Host-ID-based Authn') {
+              steps {
+                sh 'cd ci && summon --environment next ./test oc mysql host-id-based'
+              }
+            }
           }
         }
       }

--- a/ci/secrets.yml
+++ b/ci/secrets.yml
@@ -37,8 +37,8 @@ oc311:
   DOCKER_REGISTRY_URL: !var ci/openshift/3.11/registry-url
   DOCKER_REGISTRY_PATH: !var ci/openshift/3.11/registry-url
 
-oc43:
-  OPENSHIFT_VERSION: '4.3'
+oldest:
+  OPENSHIFT_VERSION: !var ci/openshift/oldest/version
   OPENSHIFT_URL: !var ci/openshift/oldest/api-url
   OPENSHIFT_USERNAME: !var ci/openshift/oldest/username
   OPENSHIFT_PASSWORD: !var ci/openshift/oldest/password
@@ -48,14 +48,14 @@ oc43:
   TEST_APP_LOADBALANCER_SVCS: false
 
   PLATFORM: openshift
-  TEST_PLATFORM: openshift43
+  TEST_PLATFORM: !var ci/openshift/oldest/version
   DOCKER_REGISTRY_URL: !var ci/openshift/oldest/registry-url
   DOCKER_REGISTRY_PATH: !var ci/openshift/oldest/registry-url
   PULL_DOCKER_REGISTRY_URL: !var ci/openshift/oldest/internal-registry-url
   PULL_DOCKER_REGISTRY_PATH: !var ci/openshift/oldest/internal-registry-url
 
-oc45:
-  OPENSHIFT_VERSION: '4.5'
+current:
+  OPENSHIFT_VERSION: !var ci/openshift/current/version
   OPENSHIFT_URL: !var ci/openshift/current/api-url
   OPENSHIFT_USERNAME: !var ci/openshift/current/username
   OPENSHIFT_PASSWORD: !var ci/openshift/current/password
@@ -63,8 +63,23 @@ oc45:
   OSHIFT_CONJUR_ADMIN_USERNAME: !var ci/openshift/current/username
 
   PLATFORM: openshift
-  TEST_PLATFORM: openshift45
+  TEST_PLATFORM: !var ci/openshift/current/version
   DOCKER_REGISTRY_URL: !var ci/openshift/current/registry-url
   DOCKER_REGISTRY_PATH: !var ci/openshift/current/registry-url
   PULL_DOCKER_REGISTRY_URL: !var ci/openshift/current/internal-registry-url
   PULL_DOCKER_REGISTRY_PATH: !var ci/openshift/current/internal-registry-url
+next:
+  OPENSHIFT_VERSION: !var ci/openshift/next/version
+  OPENSHIFT_URL: !var ci/openshift/next/api-url
+  OPENSHIFT_USERNAME: !var ci/openshift/next/username
+  OPENSHIFT_PASSWORD: !var ci/openshift/next/password
+  OSHIFT_CLUSTER_ADMIN_USERNAME: !var ci/openshift/next/username
+  OSHIFT_CONJUR_ADMIN_USERNAME: !var ci/openshift/next/username
+
+  PLATFORM: openshift
+  TEST_PLATFORM: !var ci/openshift/next/version
+  DOCKER_REGISTRY_URL: !var ci/openshift/next/registry-url
+  DOCKER_REGISTRY_PATH: !var ci/openshift/next/registry-url
+  PULL_DOCKER_REGISTRY_URL: !var ci/openshift/next/internal-registry-url
+  PULL_DOCKER_REGISTRY_PATH: !var ci/openshift/next/internal-registry-url
+

--- a/ci/test
+++ b/ci/test
@@ -188,6 +188,10 @@ function checkArguments() {
   elif [[ "$TEST_AUTHN_MODE" != "annotation-based" && "$TEST_AUTHN_MODE" != "host-id-based" ]]; then
     echo "The only valid authentication modes are 'annotation-based' and 'host-id-based'"
   else
+    if [[ "$TEST_PLATFORM" == "oc" ]]; then
+      version="${OPENSHIFT_VERSION:-UNKNOWN}"
+      announce "Test OpenShift Version $version"
+    fi
     return 0
   fi
 


### PR DESCRIPTION
This removes the hard coded Openshift versions and uses oldest, current, and next.
This also adds a flow to the Jenkinsfile for next, so next will not be run unless
you pick the option in the Jenkins UI.
Below is a view of a Jenkins run using the current and oldest, next is not run in this view as 
the option is not selected in the UI for a git push.
![Jenkins](https://user-images.githubusercontent.com/3081592/111353950-3046ed80-865c-11eb-971c-6ab51bf3e130.png)

Note: #131 should go in first, then this issue will be updated. 

Addresses issue #128 