### PR TITLE
Eliminates duplicate CONJUR_OSS_HELM_RELEASE by using HELM_RELEASE

### DIFF
--- a/5_app_store_conjur_cert.sh
+++ b/5_app_store_conjur_cert.sh
@@ -11,7 +11,7 @@ echo "Retrieving Conjur certificate."
 
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
   master_pod_name=$(get_master_pod_name)
-  ssl_cert=$($cli exec -c "${CONJUR_OSS_HELM_RELEASE_NAME}-nginx" $master_pod_name -- cat /opt/conjur/etc/ssl/cert/tls.crt)
+  ssl_cert=$($cli exec -c "${HELM_RELEASE}-nginx" $master_pod_name -- cat /opt/conjur/etc/ssl/cert/tls.crt)
 else
   if $cli get pods --selector role=follower --no-headers; then
     follower_pod_name=$($cli get pods --selector role=follower --no-headers | awk '{ print $1 }' | head -1)

--- a/ci/test
+++ b/ci/test
@@ -26,7 +26,7 @@ function finish {
   if [[ "$CONJUR_OSS" == "true" ]]; then
     runDockerCommand "
 ./stop
-helm --namespace '$CONJUR_NAMESPACE_NAME' delete '${CONJUR_OSS_HELM_RELEASE_NAME}'
+helm --namespace '$CONJUR_NAMESPACE_NAME' delete '${HELM_RELEASE}'
 kubectl delete --timeout='$KUBE_CLI_DELETE_TIMEOUT' \
   namespace $CONJUR_NAMESPACE_NAME || \
   (echo 'ERROR: Delete of namespace $CONJUR_NAMESPACE_NAME failed' && \
@@ -92,7 +92,7 @@ function deployConjur() {
 
     export CONJUR_OSS_HELM_CHART_VERSION=2.0.3
     export CONJUR_OSS_HELM_INSTALLED=true
-    export CONJUR_OSS_HELM_RELEASE_NAME="${CONJUR_NAMESPACE_NAME}"
+    export HELM_RELEASE="${CONJUR_NAMESPACE_NAME}"
 
     export CONJUR_ADMIN_PASSWORD # set below
 
@@ -150,7 +150,7 @@ helm --namespace '${CONJUR_NAMESPACE_NAME}' install \
    --set postgres.persistentVolume.create=false \
    --set rbac.create=true \
    --set 'dataKey=To7gsAFQOm7NlVnBWA3gFYlZIHC25pGwm/pMxlcHLUY=' \
-   '${CONJUR_OSS_HELM_RELEASE_NAME}' \
+   '${HELM_RELEASE}' \
    'https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v${CONJUR_OSS_HELM_CHART_VERSION}/conjur-oss-${CONJUR_OSS_HELM_CHART_VERSION}.tgz'
 
 POD_NAME=\$(kubectl get pods --namespace '${CONJUR_NAMESPACE_NAME}' \
@@ -235,7 +235,7 @@ function runDockerCommand() {
     -i \
     -e ANNOTATION_BASED_AUTHN \
     -e CONJUR_OSS_HELM_INSTALLED \
-    -e CONJUR_OSS_HELM_RELEASE_NAME \
+    -e HELM_RELEASE \
     -e CONJUR_APPLIANCE_IMAGE \
     -e CONJUR_NAMESPACE_NAME \
     -e CONJUR_ACCOUNT \


### PR DESCRIPTION
The scripts currently require that the environment variable `CONJUR_OSS_HELM_RELEASE` be set. This environment variable is set in our CI test scripts, but typical users of these scripts would not be aware that this setting is required.

Fix is to (re)use the `HELM_RELEASE` environment variable (something that users are already aware of) in our CI.

Addresses Issue #133