### PR TITLE
Adds a validator host ID for validating basic authentication

### DIFF
--- a/2_admin_load_conjur_policies.sh
+++ b/2_admin_load_conjur_policies.sh
@@ -64,7 +64,8 @@ pushd policy
     is_kubernetes=true
   fi
 
-  sed "s#{{ AUTHENTICATOR_ID }}#$AUTHENTICATOR_ID#g" ./templates/cluster-authn-svc-def.template.yml > ./generated/$TEST_APP_NAMESPACE_NAME.cluster-authn-svc.yml
+  sed "s#{{ AUTHENTICATOR_ID }}#$AUTHENTICATOR_ID#g" ./templates/cluster-authn-svc-def.template.yml |
+    sed "s#{{ CONJUR_NAMESPACE_NAME }}#$CONJUR_NAMESPACE_NAME#g" > ./generated/$TEST_APP_NAMESPACE_NAME.cluster-authn-svc.yml
 
   sed "s#{{ AUTHENTICATOR_ID }}#$AUTHENTICATOR_ID#g" ./templates/project-authn-def.template.yml |
     sed "s#{{ IS_OPENSHIFT }}#$is_openshift#g" |

--- a/policy/templates/cluster-authn-svc-def.template.yml
+++ b/policy/templates/cluster-authn-svc-def.template.yml
@@ -10,6 +10,12 @@
     annotations:
       description: authn service for cluster
 
+  - !host
+    id: validator
+    annotations:
+      description: Validation host used when configuring a cluster
+      authn-k8s/namespace: {{ CONJUR_NAMESPACE_NAME }}
+
   - !policy
     id: ca 
     body:
@@ -24,6 +30,11 @@
 
   # define layer of whitelisted authn ids permitted to call authn service
   - !layer users
+
+  # Ensure the validation host is part of the users layer
+  - !grant
+    role: !layer users
+    member: !host validator
 
   - !permit
     resource: !webservice


### PR DESCRIPTION
This change adds a special validator host ID with name 'validator'
for validating basic authentication functionality. This validator
host is very limited in what it is permitted to access:

- The validator host ID can only be used for authentication requests
  from the CONJUR_NAMESPACE_NAME Namespace.
- The validator host ID does not have access to any secrets.

The inclusion of a special validator will be suggested as an option that will
allow users to be able to validate the Kubernetes authenticator configuration
following Kubernetes cluster preparation or after application Namespace
preparation. This is described in this document:
    https://github.com/cyberark/conjur-authn-k8s-client/blob/master/design/simple-client-configuration.md
