### PR TITLE
Shorten name of flow to get tests passing in OCP 4.7

### DIFF
--- a/7_app_deploy.sh
+++ b/7_app_deploy.sh
@@ -207,22 +207,22 @@ deploy_init_container_app() {
 ###########################
 deploy_init_container_app_with_host_outside_apps() {
   $cli delete --ignore-not-found \
-    deployment/test-app-with-host-outside-apps-branch-summon-init \
-    service/test-app-with-host-outside-apps-branch-summon-init \
-    serviceaccount/test-app-with-host-outside-apps-branch-summon-init \
-    serviceaccount/oc-test-app-with-host-outside-apps-branch-summon-init
+    deployment/test-app-with-outside-host-summon-init \
+    service/test-app-with-outside-host-summon-init \
+    serviceaccount/test-app-with-outside-host-summon-init \
+    serviceaccount/oc-test-app-with-outside-host-summon-init
 
   if [[ "$PLATFORM" == "openshift" ]]; then
     oc delete --ignore-not-found \
-      deploymentconfig/test-app-with-host-outside-apps-branch-summon-init \
-      route/test-app-with-host-outside-apps-branch-summon-init
+      deploymentconfig/test-app-with-outside-host-summon-init \
+      route/test-app-with-outside-host-summon-init
   fi
 
   sleep 5
 
   conjur_authn_login="host/some-apps/$TEST_APP_NAMESPACE_NAME/*/*"
 
-  sed "s#{{ TEST_APP_DOCKER_IMAGE }}#$test_init_app_docker_image#g" ./$PLATFORM/test-app-with-host-outside-apps-branch-summon-init.yml |
+  sed "s#{{ TEST_APP_DOCKER_IMAGE }}#$test_init_app_docker_image#g" ./$PLATFORM/test-app-with-outside-host-summon-init.yml |
     sed "s#{{ AUTHENTICATOR_CLIENT_IMAGE }}#$authenticator_client_image#g" |
     sed "s#{{ IMAGE_PULL_POLICY }}#$IMAGE_PULL_POLICY#g" |
     sed "s#{{ CONJUR_ACCOUNT }}#$CONJUR_ACCOUNT#g" |
@@ -236,7 +236,7 @@ deploy_init_container_app_with_host_outside_apps() {
     $cli create -f -
 
   if [[ "$PLATFORM" == "openshift" ]]; then
-    oc expose service test-app-with-host-outside-apps-branch-summon-init
+    oc expose service test-app-with-outside-host-summon-init
   fi
 
   echo "Test app/init-container deployed."

--- a/8_app_verify_authentication.sh
+++ b/8_app_verify_authentication.sh
@@ -66,7 +66,7 @@ echo "Waiting for pods to become available"
 
 check_pods(){
   pods_ready "test-app-summon-init" &&
-  pods_ready "test-app-with-host-outside-apps-branch-summon-init" &&
+  pods_ready "test-app-with-outside-host-summon-init" &&
   pods_ready "test-app-summon-sidecar" &&
   pods_ready "test-app-secretless"
 }
@@ -77,7 +77,7 @@ if [[ "$PLATFORM" == "openshift" ]]; then
 
   check_deployment_status(){
     [[ "$(deployment_status "test-app-summon-init")" == "Complete" ]] &&
-    [[ "$(deployment_status "test-app-with-host-outside-apps-branch-summon-init")" == "Complete" ]] &&
+    [[ "$(deployment_status "test-app-with-outside-host-summon-init")" == "Complete" ]] &&
     [[ "$(deployment_status "test-app-summon-sidecar")" == "Complete" ]] &&
     [[ "$(deployment_status "test-app-secretless")" == "Complete" ]]
   }
@@ -85,7 +85,7 @@ if [[ "$PLATFORM" == "openshift" ]]; then
 
   sidecar_pod=$(get_pod_name test-app-summon-sidecar)
   init_pod=$(get_pod_name test-app-summon-init)
-  init_pod_with_host_outside_apps=$(get_pod_name test-app-with-host-outside-apps-branch-summon-init)
+  init_pod_with_host_outside_apps=$(get_pod_name test-app-with-outside-host-summon-init)
   secretless_pod=$(get_pod_name test-app-secretless)
 
   # Routes are defined, but we need to do port-mapping to access them
@@ -108,7 +108,7 @@ else
     echo "Waiting for external IPs to become available"
     check_services(){
       [[ -n "$(external_ip "test-app-summon-init")" ]] &&
-      [[ -n "$(external_ip "test-app-with-host-outside-apps-branch-summon-init")" ]] &&
+      [[ -n "$(external_ip "test-app-with-outside-host-summon-init")" ]] &&
       [[ -n "$(external_ip "test-app-summon-sidecar")" ]] &&
       [[ -n "$(external_ip "test-app-secretless")" ]]
     }
@@ -116,7 +116,7 @@ else
 
     curl_cmd=curl
     init_url=$(external_ip test-app-summon-init):8080
-    init_url_with_host_outside_apps=$(external_ip test-app-with-host-outside-apps-branch-summon-init):8080
+    init_url_with_host_outside_apps=$(external_ip test-app-with-outside-host-summon-init):8080
     sidecar_url=$(external_ip test-app-summon-sidecar):8080
     secretless_url=$(external_ip test-app-secretless):8080
 
@@ -125,7 +125,7 @@ else
     # a pod that is inside the KinD cluster.
     curl_cmd=pod_curl
     init_url="test-app-summon-init.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
-    init_url_with_host_outside_apps="test-app-with-host-outside-apps-branch-summon-init.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
+    init_url_with_host_outside_apps="test-app-with-outside-host-summon-init.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
     sidecar_url="test-app-summon-sidecar.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
     secretless_url="test-app-secretless.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
   fi

--- a/kubernetes/test-app-with-outside-host-summon-init.yml
+++ b/kubernetes/test-app-with-outside-host-summon-init.yml
@@ -2,40 +2,40 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: test-app-with-host-outside-apps-branch-summon-init
+  name: test-app-with-outside-host-summon-init
   labels:
-    app: test-app-with-host-outside-apps-branch-summon-init
+    app: test-app-with-outside-host-summon-init
 spec:
   ports:
   - protocol: TCP
     port: 8080
     targetPort: 8080
   selector:
-    app: test-app-with-host-outside-apps-branch-summon-init
+    app: test-app-with-outside-host-summon-init
   type: {{ SERVICE_TYPE }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: test-app-with-host-outside-apps-branch-summon-init
+  name: test-app-with-outside-host-summon-init
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: test-app-with-host-outside-apps-branch-summon-init
-  name: test-app-with-host-outside-apps-branch-summon-init
+    app: test-app-with-outside-host-summon-init
+  name: test-app-with-outside-host-summon-init
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: test-app-with-host-outside-apps-branch-summon-init
+      app: test-app-with-outside-host-summon-init
   template:
     metadata:
       labels:
-        app: test-app-with-host-outside-apps-branch-summon-init
+        app: test-app-with-outside-host-summon-init
     spec:
-      serviceAccountName: test-app-with-host-outside-apps-branch-summon-init
+      serviceAccountName: test-app-with-outside-host-summon-init
       containers:
       - image: {{ TEST_APP_DOCKER_IMAGE }}
         imagePullPolicy: {{ IMAGE_PULL_POLICY }}

--- a/openshift/test-app-with-outside-host-summon-init.yml
+++ b/openshift/test-app-with-outside-host-summon-init.yml
@@ -2,39 +2,39 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: test-app-with-host-outside-apps-branch-summon-init
+  name: test-app-with-outside-host-summon-init
   labels:
-    app: test-app-with-host-outside-apps-branch-summon-init
+    app: test-app-with-outside-host-summon-init
 spec:
   ports:
   - protocol: TCP
     port: 8080
     targetPort: 8080
   selector:
-    app: test-app-with-host-outside-apps-branch-summon-init
+    app: test-app-with-outside-host-summon-init
   type: {{ SERVICE_TYPE }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: oc-test-app-with-host-outside-apps-branch-summon-init
+  name: oc-test-app-with-outside-host-summon-init
 ---
 apiVersion: v1
 kind: DeploymentConfig
 metadata:
   labels:
-    app: test-app-with-host-outside-apps-branch-summon-init
-  name: test-app-with-host-outside-apps-branch-summon-init
+    app: test-app-with-outside-host-summon-init
+  name: test-app-with-outside-host-summon-init
 spec:
   replicas: 1
   selector:
-    app: test-app-with-host-outside-apps-branch-summon-init
+    app: test-app-with-outside-host-summon-init
   template:
     metadata:
       labels:
-        app: test-app-with-host-outside-apps-branch-summon-init
+        app: test-app-with-outside-host-summon-init
     spec:
-      serviceAccountName: oc-test-app-with-host-outside-apps-branch-summon-init
+      serviceAccountName: oc-test-app-with-outside-host-summon-init
       containers:
       - image: {{ TEST_APP_DOCKER_IMAGE }}
         imagePullPolicy: Always


### PR DESCRIPTION
The `test-app-with-host-outside-apps-branch-summon-init` flows exceeded the 63 char limit in OCP 4.7, leading to errors in the pipeline that looked like this:
```
[2021-05-13T18:47:47.852Z] deploymentconfig.apps.openshift.io/test-app-with-host-outside-apps-branch-summon-init created
[2021-05-13T18:47:47.852Z] The Route "test-app-with-host-outside-apps-branch-summon-init" is invalid: spec.host: Invalid value: "test-app-with-host-outside-apps-branch-summon-init-test-app-5-89f9f44a-2.apps.openshift-47-fips-enc.ci.conjur.net": host must conform to DNS 1123 naming conventions: [spec.host: Invalid value: "test-app-with-host-outside-apps-branch-summon-init-test-app-5-89f9f44a-2": must be no more than 63 characters]
```

In this PR, we update the name of those flows to something shorter. You can see them passing in OCP 4.7 [here](https://jenkins.conjur.net/blue/organizations/jenkins/conjurdemos--kubernetes-conjur-demo/detail/validate-ocp-47/2/pipeline).