### PR TITLE
Adds host IDs for validating basic authentication

### DIFF
--- a/2_admin_load_conjur_policies.sh
+++ b/2_admin_load_conjur_policies.sh
@@ -64,7 +64,15 @@ pushd policy
     is_kubernetes=true
   fi
 
+  validator_id="${VALIDATOR_ID:-validator}"
+  validator_namespace="${VALIDATOR_NAMESPACE_NAME:-$CONJUR_NAMESPACE_NAME}"
+  app_validator_id="${APP_VALIDATOR_ID:-app-validator}"
+  app_validator_namespace="${APP_VALIDATOR_NAMESPACE_NAME:-$TEST_APP_NAMESPACE_NAME}"
   sed "s#{{ AUTHENTICATOR_ID }}#$AUTHENTICATOR_ID#g" ./templates/cluster-authn-svc-def.template.yml |
+    sed "s#{{ VALIDATOR_ID }}#$validator_id#g" |
+    sed "s#{{ VALIDATOR_NAMESPACE_NAME }}#$validator_namespace#g" |
+    sed "s#{{ APP_VALIDATOR_ID }}#$app_validator_id#g" |
+    sed "s#{{ APP_VALIDATOR_NAMESPACE_NAME }}#$app_validator_namespace#g" |
     sed "s#{{ CONJUR_NAMESPACE_NAME }}#$CONJUR_NAMESPACE_NAME#g" > ./generated/$TEST_APP_NAMESPACE_NAME.cluster-authn-svc.yml
 
   sed "s#{{ AUTHENTICATOR_ID }}#$AUTHENTICATOR_ID#g" ./templates/project-authn-def.template.yml |

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ Set the following variables in your local environment:
 | `CONJUR_ADMIN_PASSWORD` | The `admin` user password that was created when you created the account on your Conjur cluster. | Yes | - | |
 | `CONJUR_AUTHN_LOGIN_RESOURCE` | Type of Kubernetes resource to use as Conjur [application identity](https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Integrations/Kubernetes_AppIdentity.htm). | No | `service_account` | `deployment` |
 | `CONJUR_NAMESPACE_NAME` | The namespace to which Conjur was deployed. | Yes | - | `conjur-namespace` |
+| `VALIDATOR_ID` | Optional host ID to include in Conjur policy for testing basic authentication following Kubernetes cluster configuration. | No | `validator` | `my-validator-id` |
+| `VALIDATOR_NAMESPACE_NAME` | The namespace from which basic authentication will be tested using VALIDATOR_ID. | No | CONJUR_NAMESPACE_NAME | `my-conjur-namespace` |
+| `APP_VALIDATOR_ID` | Optional host ID to include in Conjur policy for testing basic authentication following application Namespace configuration. | No | `app-validator` | `my-app-validator-id` |
+| `APP_VALIDATOR_NAMESPACE_NAME` | The namespace from which basic authentication will be tested using APP_VALIDATOR_ID. | No | TEST_APP_NAMESPACE_NAME | `my-app-namespace` |
 | `CONJUR_OSS_HELM_INSTALLED` | Set to `true` if you are using Conjur Open Source. | No | `false` | `true` |
 | `USE_DOCKER_LOCAL_REGISTRY` | Set to `true` if you are using a local, insecure registry to push/pull pod images. | No | `false` | `true` |
 | `DOCKER_REGISTRY_URL` | Set to the Docker registry to use for your platform for pushing/pulling application images that get built by the script. This value is mainly used for authentication. Examples are `docker.io` for DockerHub or `us.gcr.io` for GKE. | Yes | - | `us.gcr.io` |

--- a/policy/templates/cluster-authn-svc-def.template.yml
+++ b/policy/templates/cluster-authn-svc-def.template.yml
@@ -10,11 +10,21 @@
     annotations:
       description: authn service for cluster
 
+  # The VALIDATOR_ID and APP_VALIDATOR_ID host IDs can be used to validate basic
+  # authentication after a cluster or application Namespace (respectively) have
+  # been configured for authn-k8s. These host IDs do not have access to secrets
+  # (i.e. they are authenticate-only).
   - !host
-    id: validator
+    id: {{ VALIDATOR_ID }}
     annotations:
       description: Validation host used when configuring a cluster
-      authn-k8s/namespace: {{ CONJUR_NAMESPACE_NAME }}
+      authn-k8s/namespace: {{ VALIDATOR_NAMESPACE_NAME }}
+
+  - !host
+    id: {{ APP_VALIDATOR_ID }}
+    annotations:
+      description: Validation host used when configuring an application namespace
+      authn-k8s/namespace: {{ APP_VALIDATOR_NAMESPACE_NAME }}
 
   - !policy
     id: ca 
@@ -40,4 +50,5 @@
   role: !layer conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/users
   members:
     - !layer conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/apps
-    - !host conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/validator
+    - !host conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/{{ VALIDATOR_ID }}
+    - !host conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/{{ APP_VALIDATOR_ID }}


### PR DESCRIPTION
This change adds two host IDs that can be used to validate basic authentication (i.e. no secrets access is required) with a Conjur instance. The two host IDs are intended for:

- Validating authentication with Conjur after the Kubernetes cluster has been configured for Conjur authn-k8s support
- Validating authentication with Conjur after an application Namespace has been configured for Conjur authn-k8s support

respectively.