### PR TITLE
Updates Conjur OSS Helm chart to 2.0.4

### DIFF
--- a/ci/test
+++ b/ci/test
@@ -90,7 +90,7 @@ function deployConjur() {
     mkdir -p "${workdir}"
     cd "${workdir}"
 
-    export CONJUR_OSS_HELM_CHART_VERSION=2.0.3
+    export CONJUR_OSS_HELM_CHART_VERSION=2.0.4
     export CONJUR_OSS_HELM_INSTALLED=true
     export HELM_RELEASE="${CONJUR_NAMESPACE_NAME}"
 


### PR DESCRIPTION
This change updates the version of Conjur OSS Helm chart that is used
in E2E testing from version `2.0.3` to `2.0.4`.