### PR TITLE
Fix/mysql summon crashloopbackoff

### DIFF
--- a/7_app_deploy.sh
+++ b/7_app_deploy.sh
@@ -62,7 +62,7 @@ init_connection_specs() {
     secretless_image=$(platform_image_for_pull secretless-broker)
   else
     authenticator_client_image="cyberark/conjur-authn-k8s-client"
-    secretless_image="cyberark/secretless-broker"
+    secretless_image="docker.io/cyberark/secretless-broker"
   fi
 
   if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     booleanParam(
       name: 'TEST_OCP_NEXT',
       description: 'Whether or not to run the pipeline against the next OCP version',
-      defaultValue: false) 
+      defaultValue: true) 
   }
 
   stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,124 +21,124 @@ pipeline {
 
   stages {
     // Postgres Tests with Host-ID-based and Annotation-based Authn against OSS
-    stage('Deploy Demos against OSS on Openshift') {
-      parallel {
-        // stage('OpenShift v(current), v5 Conjur OSS, Postgres, Host-ID-based Authn') {
-        //   steps {
-        //     sh 'cd ci && CONJUR_OSS=true summon --environment current ./test oc postgres host-id-based'
-        //   }
-        // }
+    // stage('Deploy Demos against OSS on Openshift') {
+    //   parallel {
+    //     stage('OpenShift v(current), v5 Conjur OSS, Postgres, Host-ID-based Authn') {
+    //       steps {
+    //         sh 'cd ci && CONJUR_OSS=true summon --environment current ./test oc postgres host-id-based'
+    //       }
+    //     }
 
-        // stage('OpenShift v(current), v5 Conjur OSS, Postgres, Annotation-based Authn') {
-        //   steps {
-        //     sh 'cd ci && CONJUR_OSS=true summon --environment current ./test oc postgres annotation-based'
-        //   }
-        // }
+    //     stage('OpenShift v(current), v5 Conjur OSS, Postgres, Annotation-based Authn') {
+    //       steps {
+    //         sh 'cd ci && CONJUR_OSS=true summon --environment current ./test oc postgres annotation-based'
+    //       }
+    //     }
 
-        stage('OpenShift v(next)') {
-          // when {
-          //   expression { params.TEST_OCP_NEXT }
-          // }
-          stages {
-            stage('OpenShift v(next), v5 Conjur OSS, Postgres, Host-ID-based Authn') {
-              steps {
-                sh 'cd ci && CONJUR_OSS=true summon --environment next ./test oc postgres host-id-based'
-              }
-            }
-            stage('OpenShift v(next), v5 Conjur OSS, Postgres, Annotation-based Authn') {
-              steps {
-                sh 'cd ci && CONJUR_OSS=true summon --environment next ./test oc postgres annotation-based'
-              }
-            }
-          }
-        }
-      }
-    }
-    // Postgres Tests with Host-ID-based Auth
-    stage('Deploy Demos Postgres with Host-ID-based Authn') {
-      parallel {
-        // stage('GKE, v5 Conjur, Postgres, Host-ID-based Authn') {
-        //   steps {
-        //     sh 'cd ci && summon --environment gke ./test gke postgres host-id-based'
-        //   }
-        // }
+    //     stage('OpenShift v(next)') {
+    //       when {
+    //         expression { params.TEST_OCP_NEXT }
+    //       }
+    //       stages {
+    //         stage('OpenShift v(next), v5 Conjur OSS, Postgres, Host-ID-based Authn') {
+    //           steps {
+    //             sh 'cd ci && CONJUR_OSS=true summon --environment next ./test oc postgres host-id-based'
+    //           }
+    //         }
+    //         stage('OpenShift v(next), v5 Conjur OSS, Postgres, Annotation-based Authn') {
+    //           steps {
+    //             sh 'cd ci && CONJUR_OSS=true summon --environment next ./test oc postgres annotation-based'
+    //           }
+    //         }
+    //       }
+    //     }
+    //   }
+    // }
+    // // Postgres Tests with Host-ID-based Auth
+    // stage('Deploy Demos Postgres with Host-ID-based Authn') {
+    //   parallel {
+    //     stage('GKE, v5 Conjur, Postgres, Host-ID-based Authn') {
+    //       steps {
+    //         sh 'cd ci && summon --environment gke ./test gke postgres host-id-based'
+    //       }
+    //     }
 
-        // stage('OpenShift v3.11, v5 Conjur, Postgres, Host-ID-based Authn') {
-        //   steps {
-        //     sh 'cd ci && summon --environment oc311 ./test oc postgres host-id-based'
-        //   }
-        // }
+    //     stage('OpenShift v3.11, v5 Conjur, Postgres, Host-ID-based Authn') {
+    //       steps {
+    //         sh 'cd ci && summon --environment oc311 ./test oc postgres host-id-based'
+    //       }
+    //     }
 
-        // stage('OpenShift v(oldest), v5 Conjur, Postgres, Host-ID-based Authn') {
-        //   steps {
-        //     sh 'cd ci && summon --environment oldest ./test oc postgres host-id-based'
-        //   }
-        // }
+    //     stage('OpenShift v(oldest), v5 Conjur, Postgres, Host-ID-based Authn') {
+    //       steps {
+    //         sh 'cd ci && summon --environment oldest ./test oc postgres host-id-based'
+    //       }
+    //     }
 
-        // stage('OpenShift v(current), v5 Conjur, Postgres, Host-ID-based Authn') {
-        //   steps {
-        //     sh 'cd ci && summon --environment current ./test oc postgres host-id-based'
-        //   }
-        // }
+    //     stage('OpenShift v(current), v5 Conjur, Postgres, Host-ID-based Authn') {
+    //       steps {
+    //         sh 'cd ci && summon --environment current ./test oc postgres host-id-based'
+    //       }
+    //     }
 
-        stage('OpenShift v(next)') {
-          // when { 
-          //   expression { params.TEST_OCP_NEXT } 
-          // }
+    //     stage('OpenShift v(next)') {
+    //       when { 
+    //         expression { params.TEST_OCP_NEXT } 
+    //       }
 
-          stages {
-            stage('OpenShift v(next), v5 Conjur, Postgres, Host-ID-based Authn') {
-              steps {
-                sh 'cd ci && summon --environment next ./test oc postgres host-id-based'
-              }
-            }
-          }
-        }
-      }
-    }
+    //       stages {
+    //         stage('OpenShift v(next), v5 Conjur, Postgres, Host-ID-based Authn') {
+    //           steps {
+    //             sh 'cd ci && summon --environment next ./test oc postgres host-id-based'
+    //           }
+    //         }
+    //       }
+    //     }
+    //   }
+    // }
 
-    // Postgres Tests with Annotation-based Authn
-    stage('Deploy Demos Postgres with Annotation-based Authn') {
-      parallel {
-        // stage('GKE, v5 Conjur, Postgres, Annotation-based Authn') {
-        //   steps {
-        //     sh 'cd ci && summon --environment gke ./test gke postgres annotation-based'
-        //   }
-        // }
+    // // Postgres Tests with Annotation-based Authn
+    // stage('Deploy Demos Postgres with Annotation-based Authn') {
+    //   parallel {
+    //   stage('GKE, v5 Conjur, Postgres, Annotation-based Authn') {
+    //       steps {
+    //         sh 'cd ci && summon --environment gke ./test gke postgres annotation-based'
+    //       }
+    //     }
 
-        // stage('OpenShift v3.11, v5 Conjur, Postgres, Annotation-based Authn') {
-        //   steps {
-        //     sh 'cd ci && summon --environment oc311 ./test oc postgres annotation-based'
-        //   }
-        // }
+    //     stage('OpenShift v3.11, v5 Conjur, Postgres, Annotation-based Authn') {
+    //       steps {
+    //         sh 'cd ci && summon --environment oc311 ./test oc postgres annotation-based'
+    //       }
+    //     }
 
-        // stage('OpenShift v(oldest), v5 Conjur, Postgres, Annotation-based Authn') {
-        //   steps {
-        //     sh 'cd ci && summon --environment oldest ./test oc postgres annotation-based'
-        //   }
-        // }
+    //     stage('OpenShift v(oldest), v5 Conjur, Postgres, Annotation-based Authn') {
+    //       steps {
+    //         sh 'cd ci && summon --environment oldest ./test oc postgres annotation-based'
+    //       }
+    //     }
 
-        // stage('OpenShift v(current), v5 Conjur, Postgres, Annotation-based Authn') {
-        //   steps {
-        //     sh 'cd ci && summon --environment current ./test oc postgres annotation-based'
-        //   }
-        // }
+    //     stage('OpenShift v(current), v5 Conjur, Postgres, Annotation-based Authn') {
+    //       steps {
+    //         sh 'cd ci && summon --environment current ./test oc postgres annotation-based'
+    //       }
+    //     }
 
-        stage('OpenShift v(next)') {
-          // when {
-          //   expression { params.TEST_OCP_NEXT }
-          // }
+    //     stage('OpenShift v(next)') {
+    //       when {
+    //         expression { params.TEST_OCP_NEXT }
+    //       }
 
-          stages {
-            stage('OpenShift v(next), v5 Conjur, Postgres, Annotation-based Authn') {
-              steps {
-                sh 'cd ci && summon --environment next ./test oc postgres annotation-based'
-              }
-            }
-          }
-        }
-      }
-    }
+    //       stages {
+    //         stage('OpenShift v(next), v5 Conjur, Postgres, Annotation-based Authn') {
+    //           steps {
+    //             sh 'cd ci && summon --environment next ./test oc postgres annotation-based'
+    //           }
+    //         }
+    //       }
+    //     }
+    //   }
+    // }
 
     // MySQL Tests
     stage('Deploy Demos MySQL') {
@@ -167,9 +167,9 @@ pipeline {
           }
         }
         stage('OpenShift v(next)') {
-          // when {
-          //   expression { params.TEST_OCP_NEXT }
-          // }
+          when {
+            expression { params.TEST_OCP_NEXT }
+          }
 
           stages {
             stage('OpenShift v(next), v5 Conjur, MySQL, Host-ID-based Authn') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,22 +23,22 @@ pipeline {
     // Postgres Tests with Host-ID-based and Annotation-based Authn against OSS
     stage('Deploy Demos against OSS on Openshift') {
       parallel {
-        stage('OpenShift v(current), v5 Conjur OSS, Postgres, Host-ID-based Authn') {
-          steps {
-            sh 'cd ci && CONJUR_OSS=true summon --environment current ./test oc postgres host-id-based'
-          }
-        }
+        // stage('OpenShift v(current), v5 Conjur OSS, Postgres, Host-ID-based Authn') {
+        //   steps {
+        //     sh 'cd ci && CONJUR_OSS=true summon --environment current ./test oc postgres host-id-based'
+        //   }
+        // }
 
-        stage('OpenShift v(current), v5 Conjur OSS, Postgres, Annotation-based Authn') {
-          steps {
-            sh 'cd ci && CONJUR_OSS=true summon --environment current ./test oc postgres annotation-based'
-          }
-        }
+        // stage('OpenShift v(current), v5 Conjur OSS, Postgres, Annotation-based Authn') {
+        //   steps {
+        //     sh 'cd ci && CONJUR_OSS=true summon --environment current ./test oc postgres annotation-based'
+        //   }
+        // }
 
         stage('OpenShift v(next)') {
-          when {
-            expression { params.TEST_OCP_NEXT }
-          }
+          // when {
+          //   expression { params.TEST_OCP_NEXT }
+          // }
           stages {
             stage('OpenShift v(next), v5 Conjur OSS, Postgres, Host-ID-based Authn') {
               steps {
@@ -57,34 +57,34 @@ pipeline {
     // Postgres Tests with Host-ID-based Auth
     stage('Deploy Demos Postgres with Host-ID-based Authn') {
       parallel {
-        stage('GKE, v5 Conjur, Postgres, Host-ID-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment gke ./test gke postgres host-id-based'
-          }
-        }
+        // stage('GKE, v5 Conjur, Postgres, Host-ID-based Authn') {
+        //   steps {
+        //     sh 'cd ci && summon --environment gke ./test gke postgres host-id-based'
+        //   }
+        // }
 
-        stage('OpenShift v3.11, v5 Conjur, Postgres, Host-ID-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment oc311 ./test oc postgres host-id-based'
-          }
-        }
+        // stage('OpenShift v3.11, v5 Conjur, Postgres, Host-ID-based Authn') {
+        //   steps {
+        //     sh 'cd ci && summon --environment oc311 ./test oc postgres host-id-based'
+        //   }
+        // }
 
-        stage('OpenShift v(oldest), v5 Conjur, Postgres, Host-ID-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment oldest ./test oc postgres host-id-based'
-          }
-        }
+        // stage('OpenShift v(oldest), v5 Conjur, Postgres, Host-ID-based Authn') {
+        //   steps {
+        //     sh 'cd ci && summon --environment oldest ./test oc postgres host-id-based'
+        //   }
+        // }
 
-        stage('OpenShift v(current), v5 Conjur, Postgres, Host-ID-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment current ./test oc postgres host-id-based'
-          }
-        }
+        // stage('OpenShift v(current), v5 Conjur, Postgres, Host-ID-based Authn') {
+        //   steps {
+        //     sh 'cd ci && summon --environment current ./test oc postgres host-id-based'
+        //   }
+        // }
 
         stage('OpenShift v(next)') {
-          when { 
-            expression { params.TEST_OCP_NEXT } 
-          }
+          // when { 
+          //   expression { params.TEST_OCP_NEXT } 
+          // }
 
           stages {
             stage('OpenShift v(next), v5 Conjur, Postgres, Host-ID-based Authn') {
@@ -100,34 +100,34 @@ pipeline {
     // Postgres Tests with Annotation-based Authn
     stage('Deploy Demos Postgres with Annotation-based Authn') {
       parallel {
-      stage('GKE, v5 Conjur, Postgres, Annotation-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment gke ./test gke postgres annotation-based'
-          }
-        }
+        // stage('GKE, v5 Conjur, Postgres, Annotation-based Authn') {
+        //   steps {
+        //     sh 'cd ci && summon --environment gke ./test gke postgres annotation-based'
+        //   }
+        // }
 
-        stage('OpenShift v3.11, v5 Conjur, Postgres, Annotation-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment oc311 ./test oc postgres annotation-based'
-          }
-        }
+        // stage('OpenShift v3.11, v5 Conjur, Postgres, Annotation-based Authn') {
+        //   steps {
+        //     sh 'cd ci && summon --environment oc311 ./test oc postgres annotation-based'
+        //   }
+        // }
 
-        stage('OpenShift v(oldest), v5 Conjur, Postgres, Annotation-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment oldest ./test oc postgres annotation-based'
-          }
-        }
+        // stage('OpenShift v(oldest), v5 Conjur, Postgres, Annotation-based Authn') {
+        //   steps {
+        //     sh 'cd ci && summon --environment oldest ./test oc postgres annotation-based'
+        //   }
+        // }
 
-        stage('OpenShift v(current), v5 Conjur, Postgres, Annotation-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment current ./test oc postgres annotation-based'
-          }
-        }
+        // stage('OpenShift v(current), v5 Conjur, Postgres, Annotation-based Authn') {
+        //   steps {
+        //     sh 'cd ci && summon --environment current ./test oc postgres annotation-based'
+        //   }
+        // }
 
         stage('OpenShift v(next)') {
-          when {
-            expression { params.TEST_OCP_NEXT }
-          }
+          // when {
+          //   expression { params.TEST_OCP_NEXT }
+          // }
 
           stages {
             stage('OpenShift v(next), v5 Conjur, Postgres, Annotation-based Authn') {
@@ -167,9 +167,9 @@ pipeline {
           }
         }
         stage('OpenShift v(next)') {
-          when {
-            expression { params.TEST_OCP_NEXT }
-          }
+          // when {
+          //   expression { params.TEST_OCP_NEXT }
+          // }
 
           stages {
             stage('OpenShift v(next), v5 Conjur, MySQL, Host-ID-based Authn') {

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -21,8 +21,10 @@ RUN wget -O /usr/local/bin/kubectl ${KUBECTL_CLI_URL:-https://storage.googleapis
 ARG OPENSHIFT_CLI_URL
 RUN mkdir -p ocbin && \
     wget -O oc.tar.gz ${OPENSHIFT_CLI_URL:-https://github.com/openshift/origin/releases/download/v3.7.2/openshift-origin-client-tools-v3.7.2-282e43f-linux-64bit.tar.gz} && \
-    tar xvf oc.tar.gz --strip-components=1 -C ocbin && \
-    mv ocbin/oc /usr/local/bin/oc && \
+    tar xvf oc.tar.gz -C ocbin && \
+    ls -la ocbin && \
+    # accommodate for nested subdirectory structure for 3.* versions of oc CLI
+    if [ ! -f ocbin/oc ]; then mv ocbin/*/oc /usr/local/bin/oc ; else mv ocbin/oc /usr/local/bin/oc; fi && \
     rm -rf ocbin oc.tar.gz
 
 # Install Helm CLI

--- a/ci/secrets.yml
+++ b/ci/secrets.yml
@@ -69,6 +69,7 @@ current:
   PULL_DOCKER_REGISTRY_URL: !var ci/openshift/current/internal-registry-url
   PULL_DOCKER_REGISTRY_PATH: !var ci/openshift/current/internal-registry-url
 next:
+  OPENSHIFT_CLI_URL: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.8.2/openshift-client-linux.tar.gz
   OPENSHIFT_VERSION: !var ci/openshift/next/version
   OPENSHIFT_URL: !var ci/openshift/next/api-url
   OPENSHIFT_USERNAME: !var ci/openshift/next/username

--- a/policy/load_policies.sh
+++ b/policy/load_policies.sh
@@ -65,7 +65,7 @@ for app_name in "${APPS[@]}"; do
   else
     # The authenticator sidecar injects the full pg connection string into the
     # app environment using Summon
-    conjur variable values add "$app_name-db/url" "$PROTOCOL://$db_address/test_app"
+    conjur variable values add "$app_name-db/url" "$PROTOCOL://$db_address/test_app?enabledTLSProtocols=TLSv1,TLSv1.1,TLSv1.2"
   fi
 done
 

--- a/utils.sh
+++ b/utils.sh
@@ -252,6 +252,13 @@ function dump_kubernetes_resources() {
   $cli get -n $TEST_APP_NAMESPACE_NAME pods -o yaml
   echo "Describe pods in namespace $TEST_APP_NAMESPACE_NAME:"
   $cli describe -n $TEST_APP_NAMESPACE_NAME pods
+  echo "Logging pods in namespace $TEST_APP_NAMESPACE_NAME (summon init): ***"
+  $cli logs -n "$TEST_APP_NAMESPACE_NAME" test-app-summon-init-1
+  echo "Logging pods in namespace $TEST_APP_NAMESPACE_NAME (summon sidecar): ***"
+  $cli logs -n "$TEST_APP_NAMESPACE_NAME" test-app-summon-sidecar-1
+  echo "Logging pods in namespace $TEST_APP_NAMESPACE_NAME (test app with outside host summon init): ***"
+  $cli logs -n "$TEST_APP_NAMESPACE_NAME" test-app-with-outside-host-summon-init-1
+  echo "Logging pods in namespace $TEST_APP_NAMESPACE_NAME: ***"
   echo "Services:in namespace $TEST_APP_NAMESPACE_NAME:"
   $cli get -n $TEST_APP_NAMESPACE_NAME svc
   echo "ServiceAccounts:in namespace $TEST_APP_NAMESPACE_NAME:"

--- a/utils.sh
+++ b/utils.sh
@@ -276,3 +276,32 @@ function dump_authentication_policy {
   announce "Authentication policy:"
   cat policy/generated/$TEST_APP_NAMESPACE_NAME.project-authn.yml
 }
+
+function get_oc_version {
+  # `oc version` output differs between v3 and v4
+  local PATTERN="oc v([0-9]+.[0-9]+.[0-9]+).+"
+
+  # match `oc v3.7.2+282e43f` -> `3.7.2`
+  local ver=$($cli version | head -n 1 | grep -E "${PATTERN}" | sed -r "s/${PATTERN}/\1/")
+  if [ -z "$ver" ]
+  then
+    # match `Client Version: 4.8.2` -> `4.8.2`
+    PATTERN="Client Version: ([0-9]+\.[0-9]+\.[0-9]+)"
+    $cli version | head -n 1 | grep -E "${PATTERN}" | sed -r "s/${PATTERN}/\1/"
+  fi
+  echo $ver
+}
+
+# is_oc_major_version determines if the oc cli major version matches the given major version
+# ex) oc version -> 4.8.2; is_oc_major_version 4 -> true
+# ex) oc version -> 4.8.2; is_oc_major_version 3 -> false
+function is_oc_major_version(){
+  local major_version=$1
+  local cli_version=$(get_oc_version)
+  
+  if [[ ${cli_version:0:1} == $major_version ]]; then
+    echo true
+  else
+    echo false
+  fi
+}


### PR DESCRIPTION
> IMPORTANT: This PR is branched off of my recent PR located here: https://github.com/conjurdemos/kubernetes-conjur-demo/pull/142 (hard-coded oc cli 4.8.2 and conditional usage of its secrets api)

This PR will enable the TLS versions 1, 1.1, 1.2 via mysql connection string for mysql tests in the ci. See `load_policies.sh`. There is debate as to whether or not we want to do this via connection string or other means (via mysql odbc in java, or via the mysql base image), but this resolves issues where the summon pods were not able to connect to the mysql instances.

See:
- https://conjurhq.slack.com/archives/CQY94LJLB/p1629232501218400