### PR TITLE
Fix/openshift cli and summon tls error

### DIFF
--- a/6_app_build_and_push_containers.sh
+++ b/6_app_build_and_push_containers.sh
@@ -63,6 +63,19 @@ if [[ "$PLATFORM" != "openshift" ]]; then
       docker push $test_app_pg_image
     fi
   popd
+else
+  # If in Openshift, build and store mysql in openshift registry to circumvent
+  # rate-limiting when pulling from docker-hub.
+  docker pull centos/mysql-57-centos7
+  docker tag centos/mysql-57-centos7 $(platform_image_for_push mysql-57-centos7)
+
+  docker pull centos/mysql-80-centos7:latest
+  docker tag centos/mysql-80-centos7:latest $(platform_image_for_push mysql-80-centos7)
+
+  if ! is_minienv; then
+    docker push $(platform_image_for_push mysql-57-centos7)
+    docker push $(platform_image_for_push mysql-80-centos7)
+  fi
 fi
 
 if [[ "$LOCAL_AUTHENTICATOR" == "true" ]]; then

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,7 +100,7 @@ pipeline {
     // Postgres Tests with Annotation-based Authn
     stage('Deploy Demos Postgres with Annotation-based Authn') {
       parallel {
-      stage('GKE, v5 Conjur, Postgres, Annotation-based Authn') {
+        stage('GKE, v5 Conjur, Postgres, Annotation-based Authn') {
           steps {
             sh 'cd ci && summon --environment gke ./test gke postgres annotation-based'
           }

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -21,8 +21,9 @@ RUN wget -O /usr/local/bin/kubectl ${KUBECTL_CLI_URL:-https://storage.googleapis
 ARG OPENSHIFT_CLI_URL
 RUN mkdir -p ocbin && \
     wget -O oc.tar.gz ${OPENSHIFT_CLI_URL:-https://github.com/openshift/origin/releases/download/v3.7.2/openshift-origin-client-tools-v3.7.2-282e43f-linux-64bit.tar.gz} && \
-    tar xvf oc.tar.gz --strip-components=1 -C ocbin && \
-    mv ocbin/oc /usr/local/bin/oc && \
+    tar xvf oc.tar.gz -C ocbin && \
+    ls -la ocbin && \
+    cp "$(find ./ocbin -name 'oc' -type f | tail -1)"  /usr/local/bin/oc  && \
     rm -rf ocbin oc.tar.gz
 
 # Install Helm CLI

--- a/ci/secrets.yml
+++ b/ci/secrets.yml
@@ -69,6 +69,7 @@ current:
   PULL_DOCKER_REGISTRY_URL: !var ci/openshift/current/internal-registry-url
   PULL_DOCKER_REGISTRY_PATH: !var ci/openshift/current/internal-registry-url
 next:
+  OPENSHIFT_CLI_URL: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.8.2/openshift-client-linux.tar.gz
   OPENSHIFT_VERSION: !var ci/openshift/next/version
   OPENSHIFT_URL: !var ci/openshift/next/api-url
   OPENSHIFT_USERNAME: !var ci/openshift/next/username

--- a/kubernetes/mysql.template.yml
+++ b/kubernetes/mysql.template.yml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: test-summon-init-app-backend
-        image: {{ TEST_APP_DATABASE_DOCKER_IMAGE }}
+        image: {{ TEST_SUMMON_MYSQL_IMAGE }}
         imagePullPolicy: {{ IMAGE_PULL_POLICY }}
         ports:
           - containerPort: 3306
@@ -76,7 +76,7 @@ spec:
     spec:
       containers:
       - name: test-summon-sidecar-app-backend
-        image: {{ TEST_APP_DATABASE_DOCKER_IMAGE }}
+        image: {{ TEST_SUMMON_MYSQL_IMAGE }}
         imagePullPolicy: {{ IMAGE_PULL_POLICY }}
         ports:
           - containerPort: 3306
@@ -122,7 +122,7 @@ spec:
     spec:
       containers:
       - name: test-secretless-app-backend
-        image: {{ TEST_APP_DATABASE_DOCKER_IMAGE }}
+        image: {{ TEST_SECRETLESS_MYSQL_IMAGE }}
         imagePullPolicy: {{ IMAGE_PULL_POLICY }}
         ports:
           - containerPort: 3306

--- a/openshift/mysql.template.yml
+++ b/openshift/mysql.template.yml
@@ -30,7 +30,8 @@ spec:
     spec:
       containers:
       - name: test-summon-init-app-backend
-        image: centos/mysql-57-centos7
+        # Use 8.0 over 5.7 to resolve TLS version mismatch in OpenShift/RHEL.
+        image: {{ TEST_SUMMON_MYSQL_IMAGE }}
         imagePullPolicy: Always
         ports:
           - containerPort: 3306
@@ -74,7 +75,8 @@ spec:
     spec:
       containers:
       - name: test-summon-sidecar-app-backend
-        image: centos/mysql-57-centos7
+        # Use 8.0 over 5.7 to resolve TLS version mismatch in OpenShift/RHEL.
+        image: {{ TEST_SUMMON_MYSQL_IMAGE }}
         imagePullPolicy: Always
         ports:
           - containerPort: 3306
@@ -118,7 +120,11 @@ spec:
     spec:
       containers:
       - name: test-secretless-app-backend
-        image: centos/mysql-57-centos7
+        # Use over 5.7 over 8.0 as this does not have the TLS version mismatch
+        # issue in OpenShift/RHEL. This does have an issue with
+        # centos/mysql-80-centos8 due to lack of support for new auth mechanisms
+        # from 8.0
+        image: {{ TEST_SECRETLESS_MYSQL_IMAGE }}
         imagePullPolicy: Always
         ports:
           - containerPort: 3306


### PR DESCRIPTION
Hello, this PR resolves the following:

Issues with Openshift (Next)

- `ImagePullBackOff` error when pulling secretless-broker. This was resolved by explicitly specifying the full docker domain name. See `7_app_deploy.sh`
- Specify OCP CLI version 4.8.2 for the Openshift (Next) environment. This resolves some exceptions thrown when describing pods, and using the deprecated `secrets` api to generate and use image pull secrets
- The new secrets API is conditionally used based on the OCP CLI version, in efforts to preserve any older functionality from older versions of the CLI
- The MySQL image for OCP dropped support for an earlier version of TLS. Simply updating the MySQL image resolved this issue with no code changes. Thanks Kumbi!

References regarding MySQL TLS support:
- https://access.redhat.com/documentation/en-us/red_hat_support_for_spring_boot/2.1/html/release_notes_for_spring_boot_2.1/known-issues-spring-boot
- https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-using-ssl.html

All tests are green now =) (previously OpenShift (Next) and the MySQL tests were failing across all of OpenShift).