### PR TITLE
Remove OpenShift v3.11 support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,12 +63,6 @@ pipeline {
           }
         }
 
-        stage('OpenShift v3.11, v5 Conjur, Postgres, Host-ID-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment oc311 ./test oc postgres host-id-based'
-          }
-        }
-
         stage('OpenShift v(oldest), v5 Conjur, Postgres, Host-ID-based Authn') {
           steps {
             sh 'cd ci && summon --environment oldest ./test oc postgres host-id-based'
@@ -106,12 +100,6 @@ pipeline {
           }
         }
 
-        stage('OpenShift v3.11, v5 Conjur, Postgres, Annotation-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment oc311 ./test oc postgres annotation-based'
-          }
-        }
-
         stage('OpenShift v(oldest), v5 Conjur, Postgres, Annotation-based Authn') {
           steps {
             sh 'cd ci && summon --environment oldest ./test oc postgres annotation-based'
@@ -146,12 +134,6 @@ pipeline {
         stage('GKE, v5 Conjur, MySQL, Host-ID-based Authn') {
           steps {
             sh 'cd ci && summon --environment gke ./test gke mysql host-id-based'
-          }
-        }
-
-        stage('OpenShift v3.11, v5 Conjur, MySQL, Host-ID-based Authn') {
-          steps {
-            sh 'cd ci && summon --environment oc311 ./test oc mysql host-id-based'
           }
         }
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Supported platforms:
 
 Supported platforms:
 - Kubernetes v1.16+
-- OpenShift 3.11
+- OpenShift v4.6+
 
 To run this demo with Conjur Enterprise, you must have deployed a Conjur Enterprise follower to your
 Kubernetes cluster following the [documentation](https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Integrations/ConjurDeployFollowers.htm).

--- a/ci/secrets.yml
+++ b/ci/secrets.yml
@@ -3,7 +3,7 @@ common:
   CONJUR_ADMIN_PASSWORD: "SuperSecret!!!!123"
 
   KUBECTL_CLI_URL: https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
-  OPENSHIFT_CLI_URL: https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
+  OPENSHIFT_CLI_URL: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz
 
   GCLOUD_CLUSTER_NAME: ""
   GCLOUD_ZONE: ""
@@ -13,6 +13,7 @@ common:
   OPENSHIFT_URL: ""
   OPENSHIFT_USERNAME: ""
   OPENSHIFT_PASSWORD: ""
+
 gke:
   GCLOUD_CLUSTER_NAME: !var ci/gke/rapid/cluster-name
   GCLOUD_ZONE: !var ci/gke/zone
@@ -23,19 +24,6 @@ gke:
   TEST_PLATFORM: gke
   DOCKER_REGISTRY_URL: us.gcr.io
   DOCKER_REGISTRY_PATH: us.gcr.io/refreshing-mark-284016
-
-oc311:
-  OPENSHIFT_VERSION: '3.11'
-  OPENSHIFT_URL: !var ci/openshift/3.11/hostname
-  OPENSHIFT_USERNAME: !var ci/openshift/3.11/username
-  OPENSHIFT_PASSWORD: !var ci/openshift/3.11/password
-  OSHIFT_CLUSTER_ADMIN_USERNAME: !var ci/openshift/3.11/username
-  OSHIFT_CONJUR_ADMIN_USERNAME: !var ci/openshift/3.11/username
-
-  PLATFORM: openshift
-  TEST_PLATFORM: openshift311
-  DOCKER_REGISTRY_URL: !var ci/openshift/3.11/registry-url
-  DOCKER_REGISTRY_PATH: !var ci/openshift/3.11/registry-url
 
 oldest:
   OPENSHIFT_VERSION: !var ci/openshift/oldest/version
@@ -83,4 +71,3 @@ next:
   DOCKER_REGISTRY_PATH: !var ci/openshift/next/registry-url
   PULL_DOCKER_REGISTRY_URL: !var ci/openshift/next/internal-registry-url
   PULL_DOCKER_REGISTRY_PATH: !var ci/openshift/next/internal-registry-url
-


### PR DESCRIPTION
### Desired Outcome

Remove support for testing against OCP v3.11 as it is now EoL and we are discontinuing support.

### Implemented Changes

All references to v3.11 are removed including documentation and test tooling.

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: ONYX-22651
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
