### PR TITLE
Update DeploymentConfig apiVersion

### DIFF
--- a/openshift/test-app-secretless.yml
+++ b/openshift/test-app-secretless.yml
@@ -19,7 +19,7 @@ kind: ServiceAccount
 metadata:
   name: oc-test-app-secretless
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   labels:

--- a/openshift/test-app-summon-init.yml
+++ b/openshift/test-app-summon-init.yml
@@ -19,7 +19,7 @@ kind: ServiceAccount
 metadata:
   name: oc-test-app-summon-init
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   labels:

--- a/openshift/test-app-summon-sidecar.yml
+++ b/openshift/test-app-summon-sidecar.yml
@@ -19,7 +19,7 @@ kind: ServiceAccount
 metadata:
   name: oc-test-app-summon-sidecar
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   labels:

--- a/openshift/test-app-with-outside-host-summon-init.yml
+++ b/openshift/test-app-with-outside-host-summon-init.yml
@@ -19,7 +19,7 @@ kind: ServiceAccount
 metadata:
   name: oc-test-app-with-outside-host-summon-init
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   labels:


### PR DESCRIPTION
This PR updates the `apiVersion` for `DeploymentConfig` resources from `v1` to `apps.openshift.io/v1` to match the expected value in current versions of OpenShift.