### PR TITLE
Use Conjur CLI v8.0

### DIFF
--- a/2_admin_load_conjur_policies.sh
+++ b/2_admin_load_conjur_policies.sh
@@ -8,10 +8,10 @@ announce "Generating Conjur policy."
 prepare_conjur_cli_image() {
   announce "Pulling and pushing Conjur CLI image."
 
-  docker pull cyberark/conjur-cli:$CONJUR_VERSION-latest
+  docker pull cyberark/conjur-cli:8
 
   cli_app_image=$(platform_image_for_push conjur-cli)
-  docker tag cyberark/conjur-cli:$CONJUR_VERSION-latest $cli_app_image
+  docker tag cyberark/conjur-cli:8 $cli_app_image
 
   if ! is_minienv; then
     docker push $cli_app_image
@@ -47,8 +47,8 @@ ensure_conjur_cli_initialized() {
   fi
   conjur_url=${CONJUR_APPLIANCE_URL:-https://$conjur_service.$CONJUR_NAMESPACE_NAME.svc.cluster.local}
 
-  $cli exec $1 -- bash -c "yes yes | conjur init -a $CONJUR_ACCOUNT -u $conjur_url"
-  $cli exec $1 -- conjur authn login -u admin -p $CONJUR_ADMIN_PASSWORD
+  $cli exec $1 -- sh -c "echo y | conjur init -a $CONJUR_ACCOUNT -u $conjur_url --self-signed --force"
+  $cli exec $1 -- conjur login -i admin -p $CONJUR_ADMIN_PASSWORD
 }
 
 pushd policy
@@ -109,7 +109,7 @@ $cli exec $conjur_cli_pod -- rm -rf /policy
 $cli cp ./policy $conjur_cli_pod:/policy
 
 $cli exec $conjur_cli_pod -- \
-  bash -c "
+  sh -c "
   conjur_appliance_url=${CONJUR_APPLIANCE_URL:-https://conjur-oss.$CONJUR_NAMESPACE_NAME.svc.cluster.local}
     CONJUR_ACCOUNT=${CONJUR_ACCOUNT} \
     CONJUR_ADMIN_PASSWORD=${CONJUR_ADMIN_PASSWORD} \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,13 +23,13 @@ pipeline {
     // Postgres Tests with Host-ID-based and Annotation-based Authn against OSS
     stage('Deploy Demos against OSS on Openshift') {
       parallel {
-        stage('OpenShift v(current), v5 Conjur OSS, Postgres, Host-ID-based Authn') {
+        stage('OpenShift v(current), Conjur OSS, Postgres, Host-ID-based Authn') {
           steps {
             sh 'cd ci && CONJUR_OSS=true summon --environment current ./test oc postgres host-id-based'
           }
         }
 
-        stage('OpenShift v(current), v5 Conjur OSS, Postgres, Annotation-based Authn') {
+        stage('OpenShift v(current), Conjur OSS, Postgres, Annotation-based Authn') {
           steps {
             sh 'cd ci && CONJUR_OSS=true summon --environment current ./test oc postgres annotation-based'
           }
@@ -40,12 +40,12 @@ pipeline {
             expression { params.TEST_OCP_NEXT }
           }
           stages {
-            stage('OpenShift v(next), v5 Conjur OSS, Postgres, Host-ID-based Authn') {
+            stage('OpenShift v(next), Conjur OSS, Postgres, Host-ID-based Authn') {
               steps {
                 sh 'cd ci && CONJUR_OSS=true summon --environment next ./test oc postgres host-id-based'
               }
             }
-            stage('OpenShift v(next), v5 Conjur OSS, Postgres, Annotation-based Authn') {
+            stage('OpenShift v(next), Conjur OSS, Postgres, Annotation-based Authn') {
               steps {
                 sh 'cd ci && CONJUR_OSS=true summon --environment next ./test oc postgres annotation-based'
               }
@@ -57,19 +57,19 @@ pipeline {
     // Postgres Tests with Host-ID-based Auth
     stage('Deploy Demos Postgres with Host-ID-based Authn') {
       parallel {
-        stage('GKE, v5 Conjur, Postgres, Host-ID-based Authn') {
+        stage('GKE, Conjur Enterprise, Postgres, Host-ID-based Authn') {
           steps {
             sh 'cd ci && summon --environment gke ./test gke postgres host-id-based'
           }
         }
 
-        stage('OpenShift v(oldest), v5 Conjur, Postgres, Host-ID-based Authn') {
+        stage('OpenShift v(oldest), Conjur Enterprise, Postgres, Host-ID-based Authn') {
           steps {
             sh 'cd ci && summon --environment oldest ./test oc postgres host-id-based'
           }
         }
 
-        stage('OpenShift v(current), v5 Conjur, Postgres, Host-ID-based Authn') {
+        stage('OpenShift v(current), Conjur Enterprise, Postgres, Host-ID-based Authn') {
           steps {
             sh 'cd ci && summon --environment current ./test oc postgres host-id-based'
           }
@@ -81,7 +81,7 @@ pipeline {
           }
 
           stages {
-            stage('OpenShift v(next), v5 Conjur, Postgres, Host-ID-based Authn') {
+            stage('OpenShift v(next), Conjur Enterprise, Postgres, Host-ID-based Authn') {
               steps {
                 sh 'cd ci && summon --environment next ./test oc postgres host-id-based'
               }
@@ -94,19 +94,19 @@ pipeline {
     // Postgres Tests with Annotation-based Authn
     stage('Deploy Demos Postgres with Annotation-based Authn') {
       parallel {
-        stage('GKE, v5 Conjur, Postgres, Annotation-based Authn') {
+        stage('GKE, Conjur Enterprise, Postgres, Annotation-based Authn') {
           steps {
             sh 'cd ci && summon --environment gke ./test gke postgres annotation-based'
           }
         }
 
-        stage('OpenShift v(oldest), v5 Conjur, Postgres, Annotation-based Authn') {
+        stage('OpenShift v(oldest), Conjur Enterprise, Postgres, Annotation-based Authn') {
           steps {
             sh 'cd ci && summon --environment oldest ./test oc postgres annotation-based'
           }
         }
 
-        stage('OpenShift v(current), v5 Conjur, Postgres, Annotation-based Authn') {
+        stage('OpenShift v(current), Conjur Enterprise, Postgres, Annotation-based Authn') {
           steps {
             sh 'cd ci && summon --environment current ./test oc postgres annotation-based'
           }
@@ -118,7 +118,7 @@ pipeline {
           }
 
           stages {
-            stage('OpenShift v(next), v5 Conjur, Postgres, Annotation-based Authn') {
+            stage('OpenShift v(next), Conjur Enterprise, Postgres, Annotation-based Authn') {
               steps {
                 sh 'cd ci && summon --environment next ./test oc postgres annotation-based'
               }
@@ -131,19 +131,19 @@ pipeline {
     // MySQL Tests
     stage('Deploy Demos MySQL') {
       parallel {
-        stage('GKE, v5 Conjur, MySQL, Host-ID-based Authn') {
+        stage('GKE, Conjur Enterprise, MySQL, Host-ID-based Authn') {
           steps {
             sh 'cd ci && summon --environment gke ./test gke mysql host-id-based'
           }
         }
 
-        stage('OpenShift v(oldest), v5 Conjur, MySQL, Host-ID-based Authn') {
+        stage('OpenShift v(oldest), Conjur Enterprise, MySQL, Host-ID-based Authn') {
           steps {
             sh 'cd ci && summon --environment oldest ./test oc mysql host-id-based'
           }
         }
 
-        stage('OpenShift v(current), v5 Conjur, MySQL, Host-ID-based Authn') {
+        stage('OpenShift v(current), Conjur Enterprise, MySQL, Host-ID-based Authn') {
           steps {
             sh 'cd ci && summon --environment current ./test oc mysql host-id-based'
           }
@@ -154,7 +154,7 @@ pipeline {
           }
 
           stages {
-            stage('OpenShift v(next), v5 Conjur, MySQL, Host-ID-based Authn') {
+            stage('OpenShift v(next), Conjur Enterprise, MySQL, Host-ID-based Authn') {
               steps {
                 sh 'cd ci && summon --environment next ./test oc mysql host-id-based'
               }

--- a/ci/test
+++ b/ci/test
@@ -90,7 +90,7 @@ function deployConjur() {
     mkdir -p "${workdir}"
     cd "${workdir}"
 
-    export CONJUR_OSS_HELM_CHART_VERSION=2.0.4
+    export CONJUR_OSS_HELM_CHART_VERSION=2.0.6
     export CONJUR_OSS_HELM_INSTALLED=true
     export HELM_RELEASE="${CONJUR_NAMESPACE_NAME}"
 
@@ -119,7 +119,7 @@ spec:
       serviceAccountName: conjur-oss
       containers:
       - name: conjur-cli
-        image: cyberark/conjur-cli:5
+        image: cyberark/conjur-cli:8
         imagePullPolicy: Always
         command: ["sleep"]
         args: ["infinity"]

--- a/exec-into-cli.sh
+++ b/exec-into-cli.sh
@@ -2,5 +2,5 @@
 . utils.sh
 set_namespace $CONJUR_NAMESPACE_NAME
 conjur_cli_pod=$(get_conjur_cli_pod_name)
-$cli exec -it $conjur_cli_pod -- bash
+$cli exec -it $conjur_cli_pod -- sh
 set_namespace $TEST_APP_NAMESPACE_NAME

--- a/rotate
+++ b/rotate
@@ -17,11 +17,11 @@ readonly APPS=(
 )
 
 # Update the DB password in Conjur
-$cli exec $conjur_cli_pod -- conjur authn login -u admin -p $CONJUR_ADMIN_PASSWORD
+$cli exec $conjur_cli_pod -- conjur login -i admin -p $CONJUR_ADMIN_PASSWORD
 for app_name in "${APPS[@]}"; do
-  $cli exec $conjur_cli_pod -- conjur variable values add $app_name-db/password $new_pwd
+  $cli exec $conjur_cli_pod -- conjur variable set -i $app_name-db/password -v $new_pwd
 done
-$cli exec $conjur_cli_pod -- conjur authn logout
+$cli exec $conjur_cli_pod -- conjur logout
 
 # Update the DB password in the DB
 if [[ "$PLATFORM" = "kubernetes" ]]; then

--- a/set_env_vars.sh
+++ b/set_env_vars.sh
@@ -7,8 +7,6 @@ export PULL_DOCKER_REGISTRY_PATH=${PULL_DOCKER_REGISTRY_PATH:-${DOCKER_REGISTRY_
 PLATFORM="${PLATFORM:-kubernetes}"  # default to kubernetes if env var not set
 CONJUR_AUTHN_LOGIN_RESOURCE="${CONJUR_AUTHN_LOGIN_RESOURCE:-service_account}" # default to service_account
 
-CONJUR_VERSION="${CONJUR_VERSION:-5}"
-
 MINIKUBE="${MINIKUBE:-false}"
 MINISHIFT="${MINISHIFT:-false}"
 

--- a/utils.sh
+++ b/utils.sh
@@ -119,12 +119,12 @@ get_conjur_cli_pod_name() {
 run_conjur_cmd_as_admin() {
   local command=$(cat $@)
 
-  conjur authn logout > /dev/null
-  conjur authn login -u admin -p "$CONJUR_ADMIN_PASSWORD" > /dev/null
+  conjur logout > /dev/null
+  conjur login -i admin -p "$CONJUR_ADMIN_PASSWORD" > /dev/null
 
   local output=$(eval "$command")
 
-  conjur authn logout > /dev/null
+  conjur logout > /dev/null
   echo "$output"
 }
 
@@ -149,7 +149,7 @@ load_policy() {
   local POLICY_FILE=$1
 
   run_conjur_cmd_as_admin <<CMD
-conjur policy load --as-group security_admin "policy/$POLICY_FILE"
+conjur policy load -b root -f "policy/$POLICY_FILE"
 CMD
 }
 
@@ -157,7 +157,7 @@ rotate_host_api_key() {
   local host=$1
 
   run_conjur_cmd_as_admin <<CMD
-conjur host rotate_api_key -h $host
+conjur host rotate-api-key -i $host
 CMD
 }
 


### PR DESCRIPTION
### Desired Outcome

Update demo to use CLI v8.0.

### Implemented Changes

- Updated scripts and manifests to refer to the v8 Conjur CLI tag and use the updated command syntax.'
- Convert `load_policies.sh` script to use `sh` since new CLI container doesn't contain bash
- Use newly released version of the oss helm charts. (Depends on https://github.com/cyberark/conjur-oss-helm-chart/pull/180)

### Connected Issue/Story

CyberArk internal issue ID: ONYX-33379

Depends on https://github.com/cyberark/kubernetes-conjur-deploy/pull/183

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
