### PR TITLE
CNJR-0000: Use alpine instead of Ruby base image

### DIFF
--- a/3_admin_init_conjur_cert_authority.sh
+++ b/3_admin_init_conjur_cert_authority.sh
@@ -12,7 +12,7 @@ conjur_master=$(get_master_pod_name)
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
     $cli exec $conjur_master -c conjur-oss -- bash -c "CONJUR_ACCOUNT=$CONJUR_ACCOUNT rake authn_k8s:ca_init['conjur/authn-k8s/$AUTHENTICATOR_ID']"
 else
-    $cli exec $conjur_master -- chpst -u conjur conjur-plugin-service possum rake authn_k8s:ca_init["conjur/authn-k8s/$AUTHENTICATOR_ID"]
+    $cli exec $conjur_master -- chpst -u api:conjur conjur-plugin-service possum rake authn_k8s:ca_init["conjur/authn-k8s/$AUTHENTICATOR_ID"]
 fi
 
 echo "Certificate authority initialized."

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,15 +1,15 @@
-FROM google/cloud-sdk
+FROM ubuntu:latest
 
 RUN mkdir -p /src
 WORKDIR /src
 
 # Install Docker client
 RUN apt-get update -y && \
-    apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common wget && \
+    apt-get install -yq apt-transport-https ca-certificates curl gnupg2 software-properties-common wget && \
     curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add - && \
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable" && \
     apt-get update && \
-    apt-get install -y docker-ce && \
+    apt-get install -yq docker-ce && \
     rm -rf /var/lib/apt/lists/*
 
 # Install kubectl CLI
@@ -31,6 +31,14 @@ ARG HELM_CLI_VERSION
 RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
 RUN chmod 700 get_helm.sh
 RUN ./get_helm.sh --no-sudo --version ${HELM_CLI_VERSION:-v3.5.2}
+
+# Install Google Cloud CLI
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+    | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+    gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    apt-get update -y && \
+    apt-get install -yq google-cloud-sdk google-cloud-sdk-gke-gcloud-auth-plugin
 
 # Add the WORKDIR as a safe directory so git commands
 # can be run in containers using this image

--- a/test_app_summon/Dockerfile
+++ b/test_app_summon/Dockerfile
@@ -1,15 +1,14 @@
-FROM ruby:3.1 as test-app-builder
+FROM alpine as test-app-builder
 MAINTAINER CyberArk
 LABEL builder="test-app-builder"
 
 #---some useful tools for interactive usage---#
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl
+RUN apk add --no-cache curl bash
 
 #---install summon and summon-conjur---#
-RUN curl -sSL https://raw.githubusercontent.com/cyberark/summon/master/install.sh \
+RUN curl -sSL https://raw.githubusercontent.com/cyberark/summon/main/install.sh \
       | env TMPDIR=$(mktemp -d) bash && \
-    curl -sSL https://raw.githubusercontent.com/cyberark/summon-conjur/master/install.sh \
+    curl -sSL https://raw.githubusercontent.com/cyberark/summon-conjur/main/install.sh \
       | env TMPDIR=$(mktemp -d) bash
 # as per https://github.com/cyberark/summon#linux
 # and    https://github.com/cyberark/summon-conjur#install

--- a/test_app_summon/Dockerfile.builder
+++ b/test_app_summon/Dockerfile.builder
@@ -1,14 +1,13 @@
-FROM ruby:3.1
+FROM alpine
 MAINTAINER CyberArk
 
 #---some useful tools for interactive usage---#
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl
+RUN apk add --no-cache curl bash
 
 #---install summon and summon-conjur---#
-RUN curl -sSL https://raw.githubusercontent.com/cyberark/summon/master/install.sh \
+RUN curl -sSL https://raw.githubusercontent.com/cyberark/summon/main/install.sh \
       | env TMPDIR=$(mktemp -d) bash && \
-    curl -sSL https://raw.githubusercontent.com/cyberark/summon-conjur/master/install.sh \
+    curl -sSL https://raw.githubusercontent.com/cyberark/summon-conjur/main/install.sh \
       | env TMPDIR=$(mktemp -d) bash
 # as per https://github.com/cyberark/summon#linux
 # and    https://github.com/cyberark/summon-conjur#install


### PR DESCRIPTION
There doesn't seem to be any real reason we're using the Ruby base image for the summon test app. Summon is written in Go, and besides we're installing the compiled version. The Ruby image is large and has therefore has a large attack surface and many packages with vulnerabilities. Switching to a slimmer base image such as Alpine reduces attack surface and vulnerabilities.

While testing this, I discovered that Jenkins tests on OpenShift were failing due to the google/cloud-sdk base image used in tests no longer having the correct glibc version needed by the OpenShift CLI. I decided to switch from the (very large) google/cloud-sdk image to a plain ubuntu image and download the Google Cloud CLI as described in https://cloud.google.com/sdk/docs/install#deb