### PR TITLE
CNJR-0000: Added `close-stale.yml` GitHub workflow

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -1,0 +1,23 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write # For the Actions cache
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been inactive for 30 days. Please comment to keep it open. Otherwise, it will be automatically closed in 14 days."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale. Please feel free to reopen it or create a new issue if you think it should still be addressed."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Desired Outcome

The desired outcome is to add a GH Actions Workflow to automatically label, comment on, and close stale issues. This only handles issues for now and ignores PRs.

### Implemented Changes

Created `close-stale.yml` file in this repo with documentation from [https://docs.github.com/en/actions/use-cases-and-examples/project-management/closing-inactive-issues](https://docs.github.com/en/actions/use-cases-and-examples/project-management/closing-inactive-issues) and [https://github.com/marketplace/actions/close-stale-issues](https://github.com/marketplace/actions/close-stale-issues)

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
